### PR TITLE
型定義を追加

### DIFF
--- a/common/types/event.ts
+++ b/common/types/event.ts
@@ -1,8 +1,14 @@
 import { Topic } from './model'
 import { UserInputAction } from './userInputActions'
 
+/**
+ * WebSocketのイベント名
+ */
 export type EventType = "POST_CHAT_ITEM" | "PUB_CHAT_ITEM" | "START_EDIT" | "END_EDIT" | "ENTER_ROOM" | "BUILD_ROOM"
 
+/**
+ * POST_CHAT_ITEMイベントを送るときのイベントの中身
+ */
 export type PostChatItemParams = {
   type: "message"              // アイテムタイプ
   id: string                   // フロントで生成したアイテムID
@@ -15,34 +21,115 @@ export type PostChatItemParams = {
   reaction_to_id: string       // リアクションを送るメッセージのID
 }
 
+/**
+ * PUB_CHAT_ITEMイベントを送るときのイベントの中身
+ *
+ * @example
+ * const params: PubChatItemParams = {
+ *    actions: {
+ *      // トピック001に関するユーザーのアクション
+ *      "001": [
+ *        {
+ *          type: "insert-editing",
+ *          content: {
+ *            id: "1",
+ *          }
+ *        },
+ *        {
+ *          type: "confirm-to-send",
+ *          content: {
+ *            // ...省略
+ *          }
+ *        },
+ *      // ...
+ *      ],
+ *      // トピック002に関するユーザーのアクション
+ *      "002": [ ... 省略]
+ *    }
+ *  }
+ * }
+ */
 export type PubChatItemParams = {
   actions: Record<string, UserInputAction[]>
 }
 
+/**
+ * START_EDITイベントを送るときのイベントの中身
+ */
 export type StartEditParams = {
   "id": string        // フロントで生成したアイテムID
   "topic_id": string  // トピックID
 }
 
+/**
+ * END_EDITイベントを送るときのイベントの中身
+ */
 export type EndEditParams = {
   id: string
   topic_id: string
 }
 
+/**
+ * ENTER_ROOMイベントを送るときのイベントの中身
+ */
 export type EnterRoomParams = {
   icon_id: string
 }
 
+/**
+ * ENTER_ROOMイベントを送ったときのレスポンスの中身
+ *
+ * @example
+ * const response: EnterRoomResponse = {
+ *    actions: {
+ *      // トピック001に関するユーザーのアクション
+ *      "001": [
+ *        {
+ *          type: "insert-editing",
+ *          content: {
+ *            id: "1",
+ *          }
+ *        },
+ *        {
+ *          type: "confirm-to-send",
+ *          content: {
+ *            // ...省略
+ *          }
+ *        },
+ *      // ...
+ *      ],
+ *      // トピック002に関するユーザーのアクション
+ *      "002": [ ... 省略]
+ *     }
+ *   },
+ *   topics: [
+ *     { id: "001", title: "タイトル", description: "説明" },
+ *     { id: "002", title: "タイトル", description: "説明" },
+ *     ...
+ *   ]
+ * }
+ */
 export type EnterRoomResponse = {
   actions: Record<string, UserInputAction>,
   topics: Topic[]
 }
 
+/**
+ * BUILD_ROOMイベントを送ったときのレスポンスの中身
+ */
 export type BuildRoomParams = {
   id: string
   topics: Topic[]
 }
 
+/**
+ * イベント名を引数にとって、イベントを送るときの型を返す
+ *
+ * @example
+ * const params: EventParams<"START_EDIT"> = {
+ *   id: "1234", topoc_id: "2"
+ * }
+ */
 export type EventParams<EventName extends EventType> =
     EventName extends "POST_CHAT_ITEM" ? PostChatItemParams :
     EventName extends "PUB_CHAT_ITEM" ? PubChatItemParams :
@@ -51,5 +138,13 @@ export type EventParams<EventName extends EventType> =
     EventName extends "ENTER_ROOM" ? EnterRoomParams :
     EventName extends "BUILD_ROOM" ? BuildRoomParams : never;
 
+/**
+ * イベント名を引数にとって、イベントを送ったときのレスポンスの型を返す
+ *
+ * @example
+ * const params: EventResponse<"ENTER_ROOM"> = {
+ *   actions: { ... }, topocs: [ ... ]
+ * }
+ */
 export type EventResponse<EventName extends EventType> =
     EventName extends "ENTER_ROOM" ? EnterRoomResponse : void;

--- a/common/types/event.ts
+++ b/common/types/event.ts
@@ -1,0 +1,55 @@
+import { Topic } from './model'
+import { UserInputAction } from './userInputActions'
+
+export type EventType = "POST_CHAT_ITEM" | "PUB_CHAT_ITEM" | "START_EDIT" | "END_EDIT" | "ENTER_ROOM" | "BUILD_ROOM"
+
+export type PostChatItemParams = {
+  type: "message"              // アイテムタイプ
+  id: string                   // フロントで生成したアイテムID
+  topic_id: string             // トピックID
+  content: string              // コメントの中身
+} | {
+  type: "reaction"             // アイテムタイプ
+  id: string                   // フロントで生成したアイテムID
+  topic_id: string             // トピックID
+  reaction_to_id: string       // リアクションを送るメッセージのID
+}
+
+export type PubChatItemParams = {
+  actions: Record<string, UserInputAction[]>
+}
+
+export type StartEditParams = {
+  "id": string        // フロントで生成したアイテムID
+  "topic_id": string  // トピックID
+}
+
+export type EndEditParams = {
+  id: string
+  topic_id: string
+}
+
+export type EnterRoomParams = {
+  icon_id: string
+}
+
+export type EnterRoomResponse = {
+  actions: Record<string, UserInputAction>,
+  topics: Topic[]
+}
+
+export type BuildRoomParams = {
+  id: string
+  topics: Topic[]
+}
+
+export type EventParams<EventName extends EventType> =
+    EventName extends "POST_CHAT_ITEM" ? PostChatItemParams :
+    EventName extends "PUB_CHAT_ITEM" ? PubChatItemParams :
+    EventName extends "START_EDIT" ? StartEditParams :
+    EventName extends "END_EDIT" ? EndEditParams :
+    EventName extends "ENTER_ROOM" ? EnterRoomParams :
+    EventName extends "BUILD_ROOM" ? BuildRoomParams : never;
+
+export type EventResponse<EventName extends EventType> =
+    EventName extends "ENTER_ROOM" ? EnterRoomResponse : void;

--- a/common/types/model.ts
+++ b/common/types/model.ts
@@ -14,6 +14,7 @@ export type ChatItemBase = {
  */
 export type Message = ChatItemBase & {
   "content": string              // メッセージの内容
+  "is_question": boolean
 }
 
 /**

--- a/common/types/model.ts
+++ b/common/types/model.ts
@@ -1,0 +1,42 @@
+/**
+ * ChatItemの共通プロパティ
+ */
+export type ChatItemBase = {
+  "id": string                   // アイテムID
+  "topic_id": string             // トピックID
+  "type": string                 // コメントタイプ
+  "icon_id": string              // アイコンID
+  "timestamp": number            // 経過時間のタイムスタンプ
+}
+
+/**
+ * メッセージモデル
+ */
+export type Message = ChatItemBase & {
+  "content": string              // メッセージの内容
+}
+
+/**
+ * リアクションモデル
+ */
+export type Reaction = ChatItemBase & {
+  "target": {
+     "id": string                // リアクションを行なった対象のメッセージID
+     "content": string           // リアクションを行なった対象のメッセージの内容
+   }
+}
+
+/**
+ * チャットアイテムモデル
+ */
+export type ChatItem = Message | Reaction
+
+/**
+ * トピックモデル
+ */
+export type Topic = {
+  "id": string                   // トピックID
+  "title": string                // トピックのタイトル
+  "description": string          // トピックの説明
+}
+

--- a/common/types/userInputActions.ts
+++ b/common/types/userInputActions.ts
@@ -1,10 +1,9 @@
 import { ChatItem } from './model'
 
 export type InsertEditingAction = {
-  type: "nsert-editing",
+  type: "insert-editing",
   content: {
     "id": string,
-    "topic_id": string
   }
 }
 

--- a/common/types/userInputActions.ts
+++ b/common/types/userInputActions.ts
@@ -1,0 +1,28 @@
+import { ChatItem } from './model'
+
+export type InsertEditingAction = {
+  type: "nsert-editing",
+  content: {
+    "id": string,
+    "topic_id": string
+  }
+}
+
+export type RemoveEditingAction = {
+  type: "remove-editing"
+  content: {
+    "id": string
+  }
+}
+
+export type ConfirmToSendAction = {
+  type: "confirm-to-send",
+  content: ChatItem
+}
+
+export type InsertChatItemAction = {
+  type: "insert-chatitem",
+  content: ChatItem
+}
+
+export type UserInputAction = InsertEditingAction | RemoveEditingAction | ConfirmToSendAction | InsertChatItemAction


### PR DESCRIPTION
今更だけどWikiのAPI定義にある型をcommonに追加しました。フロント・サーバーから直接importしても良いし（もしかしたら何かに怒られてできないかも）、それぞれのディレクトリにコピってもらっても大丈夫です。既にフロント・サーバーで定義済みであればそれを使ってもらって大丈夫です。