### PR TITLE
30秒でイベント送信(後修正)

### DIFF
--- a/server/src/ioServer.ts
+++ b/server/src/ioServer.ts
@@ -27,9 +27,16 @@ const createSocketIOServer = (httpServer: HttpServer) => {
   let stampCount: number = 0;
   let firstCommentTime: number = 0;
 
+  setInterval(() => {
+    if (activeUserCount > 0) {
+      io.sockets.emit("");
+    }
+  }, 30000);
+
   //本体
   io.on("connection", (socket) => {
     console.log("user joined");
+    activeUserCount++;
 
     //ルーム参加
     socket.on("ENTER_ROOM", (received: EnterRoomReceive, callback: any) => {

--- a/server/src/ioServer.ts
+++ b/server/src/ioServer.ts
@@ -27,11 +27,15 @@ const createSocketIOServer = (httpServer: HttpServer) => {
   let stampCount: number = 0;
   let firstCommentTime: number = 0;
 
+  //サーバー起こしておくため
   setInterval(() => {
     if (activeUserCount > 0) {
       io.sockets.emit("");
     }
   }, 30000);
+
+  //このこが2秒毎にスタンプを送る
+  stampIntervalSender(io, stamps);
 
   //本体
   io.on("connection", (socket) => {
@@ -114,9 +118,6 @@ const createSocketIOServer = (httpServer: HttpServer) => {
         topicId: received.topicId,
       });
     });
-
-    //このこが2秒毎にスタンプを送る
-    stampIntervalSender(io, stamps);
 
     //接続解除時に行う処理
     socket.on("disconnect", (reason) => {

--- a/server/src/ioServer.ts
+++ b/server/src/ioServer.ts
@@ -35,7 +35,7 @@ const createSocketIOServer = (httpServer: HttpServer) => {
   }, 30000);
 
   //このこが2秒毎にスタンプを送る
-  stampIntervalSender(io, stamps);
+  stampIntervalSender(io, stamps, activeUserCount);
 
   //本体
   io.on("connection", (socket) => {

--- a/server/src/ioServer.ts
+++ b/server/src/ioServer.ts
@@ -27,26 +27,30 @@ const createSocketIOServer = (httpServer: HttpServer) => {
   let stampCount: number = 0;
   let firstCommentTime: number = 0;
 
-  //サーバー起こしておくため
-  setInterval(() => {
-    if (activeUserCount > 0) {
-      io.sockets.emit("");
-    }
-  }, 30000);
+  let serverAwakerTimer: NodeJS.Timeout;
+  let stampIntervalSenderTimer: NodeJS.Timeout;
 
-  //このこが2秒毎にスタンプを送る
-  stampIntervalSender(io, stamps, activeUserCount);
+  //サーバー起こしておくため
+  function serverAwaker() {
+    return setInterval(() => {
+      io.sockets.emit("");
+      console.log("awaker stamp", new Date());
+    }, 30000);
+  }
 
   //本体
   io.on("connection", (socket) => {
     console.log("user joined");
     activeUserCount++;
+    if (activeUserCount === 1) {
+      //サーバー起こしておくため
+      serverAwakerTimer = serverAwaker();
+      stampIntervalSenderTimer = stampIntervalSender(io, stamps);
+    }
 
     //ルーム参加
     socket.on("ENTER_ROOM", (received: EnterRoomReceive, callback: any) => {
       console.log("entered");
-
-      activeUserCount++;
       users[socket.id] = received.iconId.toString();
       const sortedChatItem = Object.values(chatItems).sort(function (a, b) {
         if (a.timestamp < b.timestamp) return 1;
@@ -123,6 +127,12 @@ const createSocketIOServer = (httpServer: HttpServer) => {
     socket.on("disconnect", (reason) => {
       console.log("disconnect: ", reason);
       activeUserCount--;
+      if (activeUserCount === 0) {
+        //サーバー起こしておくこ
+        clearInterval(serverAwakerTimer);
+        //このこが2秒毎にスタンプを送る
+        clearInterval(stampIntervalSenderTimer);
+      }
     });
   });
 

--- a/server/src/stamp.ts
+++ b/server/src/stamp.ts
@@ -4,15 +4,13 @@ export type Stamp = {
   topicId: string;
 };
 
-export function stampIntervalSender(
-  io: Server,
-  stamps: Stamp[],
-  activeUserCount: number
-) {
-  setInterval(() => {
-    if (activeUserCount) {
+export function stampIntervalSender(io: Server, stamps: Stamp[]) {
+  return setInterval(() => {
+    if (stamps.length > 0) {
       io.sockets.emit("PUB_STAMP", stamps);
+      stamps.length = 0;
+      console.log("inner stamp", new Date());
     }
-    stamps.length = 0;
+    console.log("onter stamp", new Date());
   }, 2000);
 }

--- a/server/src/stamp.ts
+++ b/server/src/stamp.ts
@@ -4,9 +4,15 @@ export type Stamp = {
   topicId: string;
 };
 
-export function stampIntervalSender(io: Server, stamps: Stamp[]) {
+export function stampIntervalSender(
+  io: Server,
+  stamps: Stamp[],
+  activeUserCount: number
+) {
   setInterval(() => {
-    io.sockets.emit("PUB_STAMP", stamps);
+    if (activeUserCount) {
+      io.sockets.emit("PUB_STAMP", stamps);
+    }
     stamps.length = 0;
   }, 2000);
 }


### PR DESCRIPTION
30秒ごとに空のイベント送ります。マジで空やけど、名前くらいつけてもいいのかもしれない。

ちなみに、
’io.on("connection", (socket) => {hogehoge})’
の中に書くとユーザーの数分実行されるらしく、修正しました

’io.once("connection"'
でもできるはずだけど効果なかった……