### PR TITLE
アイコンをlocalStroageに保存する処理を追加

### DIFF
--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -73,6 +73,7 @@ import {
 import ChatRoom from '@/components/ChatRoom.vue'
 import { io } from 'socket.io-client'
 import getUUID from '@/utils/getUUID'
+import { getSelectedIcon, setSelectedIcon } from '@/utils/reserveSelectIcon'
 
 // 1つのトピックと、そのトピックに関するメッセージ一覧を含むデータ構造
 type ChatData = {
@@ -128,14 +129,20 @@ export default Vue.extend({
     },
   },
   mounted(): any {
+    const socket = io(process.env.apiBaseUrl as string)
+    ;(this as any).socket = socket
+
     if (this.isAdmin) {
       this.$modal.show('topic-modal')
     } else {
-      this.$modal.show('sushi-modal')
+      const selectedIcon = getSelectedIcon()
+      if (selectedIcon == null) {
+        this.$modal.show('sushi-modal')
+      } else {
+        this.iconChecked = selectedIcon - 1
+        this.enterRoom(selectedIcon)
+      }
     }
-
-    const socket = io(process.env.apiBaseUrl as string)
-    ;(this as any).socket = socket
 
     // FIXME: サーバからデータが送られてこないので暫定的に対応 (yuta-ike)
     this.topics.push({ id: '0', title: 'タイトル', description: '説明' })
@@ -204,12 +211,14 @@ export default Vue.extend({
       } else {
         this.$modal.hide('sushi-modal')
       }
-
+      this.enterRoom(this.iconChecked + 1)
+    },
+    enterRoom(iconId: number) {
       const socket = (this as any).socket
       socket.emit(
         'ENTER_ROOM',
         {
-          iconId: this.iconChecked + 1,
+          iconId,
         },
         (res: any) => {
           // FIXME: サーバから空のデータが送られてくるので暫定的にコメントアウト(yuta-ike)
@@ -217,6 +226,7 @@ export default Vue.extend({
           this.messages = res.chatItems ?? []
         }
       )
+      setSelectedIcon(iconId)
     },
     // 該当するtopicを削除
     removeTopic(index: number) {

--- a/app/front/utils/reserveSelectIcon.ts
+++ b/app/front/utils/reserveSelectIcon.ts
@@ -1,0 +1,15 @@
+const SUSHI_CHAT_SELECTED_ICON_KEY = 'SUSHI_CHAT_SELECTED_ICON_KEY'
+
+export const getSelectedIcon = () => {
+  const iconIdOrNull = localStorage.getItem(SUSHI_CHAT_SELECTED_ICON_KEY)
+  if (iconIdOrNull == null) {
+    return null
+  } else {
+    // stringをnumberに変換
+    const iconId = Number(iconIdOrNull)
+    return Number.isNaN(iconId) ? null : iconId
+  }
+}
+
+export const setSelectedIcon = (iconId: number) =>
+  localStorage.setItem(SUSHI_CHAT_SELECTED_ICON_KEY, `${iconId}`)


### PR DESCRIPTION
開発時にモーダルが出てうるさいので、アイコンIDをlocalStorageに保存するように変更
- localStorageにアイコンIDが保存されている場合はその値を利用し、存在しない場合はモーダルを出す