### PR TITLE
ルームをオープンするボタンが一般ユーザーにも表示されてしまうバグを解決

### DIFF
--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="container page">
-    <header>
+    <header v-if="isAdmin">
       <button @click="clickDrawerMenu">
         <span class="material-icons"> {{ hamburgerMenu }} </span>
       </button>
-      <button v-if="isAdmin && !isRoomStarted" @click="startRoom">
+      <button v-if="!isRoomStarted" @click="startRoom">
         ルームをオープンする
       </button>
     </header>
@@ -95,7 +95,7 @@
           </div>
         </div>
       </modal>
-      <SettingPage v-if="isDrawer" />
+      <SettingPage v-if="isDrawer && isAdmin" />
       <div v-for="(chatData, index) in chatDataList" :key="index">
         <ChatRoom
           :topic-index="index"

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="container page">
-    <header :v-show="isAdmin">
+    <header>
       <button @click="clickDrawerMenu">
         <span class="material-icons"> {{ hamburgerMenu }} </span>
       </button>
-      <button v-show="!isRoomStarted" @click="startRoom">
+      <button v-if="isAdmin && !isRoomStarted" @click="startRoom">
         ルームをオープンする
       </button>
     </header>

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -347,7 +347,7 @@ export default Vue.extend({
         },
         (room: AdminBuildRoomResponse) => {
           this.room = room
-          console.log(room)
+          console.log(`ルームID: ${room.id}`)
           socket.emit(
             'ADMIN_ENTER_ROOM',
             {


### PR DESCRIPTION
#167 
- ルームをオープンするボタンを管理者にのみ表示
- ハンバーガーボタンとドロワーを管理者にのみ表示
- ルームIDの表示を見やすくした