### PR TITLE
自分が投稿したコメントのタイムスタンプのバグを修正

### DIFF
--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -68,6 +68,12 @@
       &:active {
         background: rgba(187, 187, 187, 0.3);
       }
+
+      &:disabled {
+        color: rgba(204, 204, 204, 0.5);
+        background: transparent;
+        cursor: default;
+      }
     }
   }
 }

--- a/app/front/components/TopicHeader.vue
+++ b/app/front/components/TopicHeader.vue
@@ -11,6 +11,7 @@
       <button
         v-show="isAdmin"
         class="download-button"
+        :disabled="topicState === 'active'"
         @click="clickTopicActivate"
       >
         <zap-icon size="18"></zap-icon>

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -243,10 +243,12 @@ export default Vue.extend({
     // SocketIOのコールバックの登録
     socket.on('PUB_CHAT_ITEM', (chatItem: ChatItem) => {
       if (this.messages.find(({ id }) => id === chatItem.id)) {
+        // 自分が送信したコメント
         this.messages = this.messages.map((item) =>
           item.id === chatItem.id ? chatItem : item
         )
       } else {
+        // 自分以外のユーザーが送信したコメント
         this.messages.push(chatItem)
       }
     })
@@ -452,7 +454,7 @@ export default Vue.extend({
         content: text,
         createdAt: new Date(),
         target,
-        timestamp: 60000, // TODO: 正しいタイムスタンプを設定する
+        timestamp: 0, // TODO: 正しいタイムスタンプを設定する
       })
     },
     sendReaction(message: Message) {

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -242,7 +242,13 @@ export default Vue.extend({
 
     // SocketIOのコールバックの登録
     socket.on('PUB_CHAT_ITEM', (chatItem: ChatItem) => {
-      this.messages.push(chatItem)
+      if (this.messages.find(({ id }) => id === chatItem.id)) {
+        this.messages = this.messages.map((item) =>
+          item.id === chatItem.id ? chatItem : item
+        )
+      } else {
+        this.messages.push(chatItem)
+      }
     })
 
     socket.on('PUB_CHANGE_TOPIC_STATE', (res: any) => {

--- a/server/src/models/room.ts
+++ b/server/src/models/room.ts
@@ -84,7 +84,11 @@ class RoomClass {
       state: "not-started",
     }));
     this.topics.forEach(({ id }) => {
-      this.topicTimeData[id] = { openedDate: null, pausedDate: null, offsetTime: 0 };
+      this.topicTimeData[id] = {
+        openedDate: null,
+        pausedDate: null,
+        offsetTime: 0,
+      };
     });
   }
 
@@ -164,7 +168,8 @@ class RoomClass {
 
       const pausedDate = this.topicTimeData[targetTopic.id].pausedDate;
       if (pausedDate != null) {
-        this.topicTimeData[targetTopic.id].offsetTime += new Date().getTime() - pausedDate;
+        this.topicTimeData[targetTopic.id].offsetTime +=
+          new Date().getTime() - pausedDate;
       }
     } else if (params.type === "PAUSE") {
       targetTopic.state = "paused";
@@ -186,7 +191,10 @@ class RoomClass {
         this.id,
         this.stampsQueue
       );
-    } else if (this.activeTopic == null && this.stampIntervalSenderTimer != null) {
+    } else if (
+      this.activeTopic == null &&
+      this.stampIntervalSenderTimer != null
+    ) {
       // 全部閉じたならタイマー解除
       clearInterval(this.stampIntervalSenderTimer);
       //c learIntervalしてもタイマーは残るので、あとでわかるように消す
@@ -228,7 +236,10 @@ class RoomClass {
    * @param userId
    * @param chatItemParams
    */
-  public postChatItem = (userId: string, chatItemParams: PostChatItemParams) => {
+  public postChatItem = (
+    userId: string,
+    chatItemParams: PostChatItemParams
+  ) => {
     if (!this.isOpened) {
       throw new Error("[sushi-chat-server] Room is not opened.");
     }
@@ -242,7 +253,7 @@ class RoomClass {
     // 配列に保存
     this.chatItems.push(chatItem);
     // サーバでの保存形式をフロントに返すレスポンスの形式に変換して配信する
-    this.getSocketByUserId(userId).broadcast(
+    RoomClass.globalSocket.emit(
       "PUB_CHAT_ITEM",
       this.chatItemStoreToChatItem(chatItem)
     );
@@ -254,7 +265,10 @@ class RoomClass {
    * @param chatItem チャットアイテム
    * @returns
    */
-  private addServerInfo = (userId: string, chatItem: PostChatItemParams): ChatItemStore => {
+  private addServerInfo = (
+    userId: string,
+    chatItem: PostChatItemParams
+  ): ChatItemStore => {
     const timestamp = this.getTimestamp(chatItem.topicId);
     if (chatItem.type === "reaction") {
       const { reactionToId, ...rest } = chatItem;
@@ -282,7 +296,9 @@ class RoomClass {
    * @param chatItemStore
    * @returns フロントに返すためのデータ
    */
-  private chatItemStoreToChatItem = (chatItemStore: ChatItemStore): ChatItem => {
+  private chatItemStoreToChatItem = (
+    chatItemStore: ChatItemStore
+  ): ChatItem => {
     if (chatItemStore.type === "message") {
       if (chatItemStore.target == null) {
         // 通常メッセージ
@@ -294,14 +310,20 @@ class RoomClass {
         // リプライメッセージ
         // リプライ先のメッセージを取得する
         const targetChatItemStore = this.chatItems.find(
-          ({ id, type }) => id === chatItemStore.target && (type === "answer" || type === "message")
+          ({ id, type }) =>
+            id === chatItemStore.target &&
+            (type === "answer" || type === "message")
         );
         if (targetChatItemStore == null) {
-          throw new Error("[sushi-chat-server] Reply target message does not exists.");
+          throw new Error(
+            "[sushi-chat-server] Reply target message does not exists."
+          );
         }
         return {
           ...chatItemStore,
-          target: this.chatItemStoreToChatItem(targetChatItemStore) as Answer | Message,
+          target: this.chatItemStoreToChatItem(targetChatItemStore) as
+            | Answer
+            | Message,
         };
       }
     } else if (chatItemStore.type === "reaction") {
@@ -312,11 +334,16 @@ class RoomClass {
           (type === "message" || type === "question" || type === "answer")
       );
       if (targetChatItemStore == null) {
-        throw new Error("[sushi-chat-server] Reaction target message does not exists.");
+        throw new Error(
+          "[sushi-chat-server] Reaction target message does not exists."
+        );
       }
       return {
         ...chatItemStore,
-        target: this.chatItemStoreToChatItem(targetChatItemStore) as Message | Answer | Question,
+        target: this.chatItemStoreToChatItem(targetChatItemStore) as
+          | Message
+          | Answer
+          | Question,
       };
     } else if (chatItemStore.type === "question") {
       // 質問
@@ -327,7 +354,9 @@ class RoomClass {
         ({ id, type }) => id === chatItemStore.target && type === "question"
       );
       if (targetChatItemStore == null) {
-        throw new Error("[sushi-chat-server] Answer target message does not exists.");
+        throw new Error(
+          "[sushi-chat-server] Answer target message does not exists."
+        );
       }
       return {
         ...chatItemStore,
@@ -344,7 +373,10 @@ class RoomClass {
       // NOTE: エラー
       return 0;
     }
-    const timestamp = new Date().getTime() - openedDate - this.topicTimeData[topicId].offsetTime;
+    const timestamp =
+      new Date().getTime() -
+      openedDate -
+      this.topicTimeData[topicId].offsetTime;
     return timestamp < 0 ? 0 : timestamp;
   };
 


### PR DESCRIPTION
## やったこと
- コメントが投稿されたとき、投稿者を含む全ユーザーにメッセージを送信するように変更
  - 今までは自分の投稿はローカルに反映させていたが、タイムスタンプが反映されない問題があったので、自分のコメントもサーバーから受ける形に変更
  - ただ即時反映はしたいので、自分が投稿したコメントは即時反映させ、サーバーからタイムスタンプ付きのメッセージが届き次第、それに置き換える形で実装しています

- アクティブなトピックの雷ボタンを押せないように変更