### PR TITLE
mainからdevelopへの自動PRを行う

### DIFF
--- a/.github/workflows/pulling-into-develop.yml
+++ b/.github/workflows/pulling-into-develop.yml
@@ -1,0 +1,18 @@
+name: Pulling into develop
+on:
+  push:
+    branches:
+      - main
+jobs:
+  pulling_into_develop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: create-pull-request
+        uses: repo-sync/pull-request@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: "main"
+          destination_branch: "develop"
+          pr_title: "Pulling ${{ github.ref }} into develop"
+          pr_body: "Pulling ${{ github.ref }} into develop"


### PR DESCRIPTION
## やったこと
mainブランチに変更があった場合、自動でdevelopブランチへのPRを出すスクリプトを追加。
テストのやりようがないのでちゃんと動くかわからん.......

## 目的
mainブランチにマージされたバグ修正などを自動でdevelopへ取り込むため。

## 参考
[Zenn](https://zenn.dev/kehonda/articles/a5b08e9df03d13#1.master%E3%81%AB%E6%9B%B4%E6%96%B0%E3%81%8C%E3%81%82%E3%81%A3%E3%81%9F%E3%81%A8%E3%81%8D%E3%80%81develop%E3%81%AB%E5%90%91%E3%81%91%E3%81%9Fpr%E3%82%92%E8%87%AA%E5%8B%95%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B)