### PR TITLE
デバイスによってctrl+enterで送信の表示を変える

### DIFF
--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -267,11 +267,6 @@
       color: red;
     }
   }
-  @media screen and (max-width: 768px) {
-    & > .key-instruct {
-      display: none;
-    }
-  }
 
   & > .question-checkbox {
     font-size: 85%;

--- a/app/front/components/ChatRoom.vue
+++ b/app/front/components/ChatRoom.vue
@@ -56,13 +56,20 @@
       :topic="chatData.topic"
       :my-icon="myIcon"
       :disabled="isNotStartedTopic"
+      :device-type="deviceType"
       @submit="clickSubmit"
     />
   </article>
 </template>
 <script lang="ts">
 import Vue, { PropOptions } from 'vue'
-import { Topic, ChatItem, Message, TopicState } from '@/models/contents'
+import {
+  Topic,
+  ChatItem,
+  Message,
+  TopicState,
+  DeviceType,
+} from '@/models/contents'
 import TopicHeader from '@/components/TopicHeader.vue'
 import MessageComponent from '@/components/Message.vue'
 import TextArea from '@/components/TextArea.vue'
@@ -123,6 +130,10 @@ export default Vue.extend({
       type: Boolean,
       default: false,
     },
+    deviceType: {
+      type: String,
+      default: 'windows',
+    } as PropOptions<DeviceType>,
   },
   data(): DataType {
     return {

--- a/app/front/components/KeyInstruction.vue
+++ b/app/front/components/KeyInstruction.vue
@@ -1,7 +1,23 @@
 <template>
-  <div class="key-instruct">
-    <span class="key-span">ENTER</span>で改行、<span class="key-span"
-      >Ctrl(⌘)</span
-    >+<span class="key-span">ENTER</span>で送信
+  <div v-if="deviceType != 'smartphone'" class="key-instruct">
+    <span class="key-span">ENTER</span>で改行、
+    <span v-if="deviceType === 'mac'" class="key-span">⌘</span>
+    <span v-if="deviceType === 'windows'" class="key-span">Ctrl</span>
+    +<span class="key-span">ENTER</span>で送信
   </div>
 </template>
+
+<script lang="ts">
+import Vue, { PropOptions } from 'vue'
+import { DeviceType } from '@/models/contents'
+
+export default Vue.extend({
+  name: 'KeyInstruction',
+  props: {
+    deviceType: {
+      type: String,
+      default: 'windows',
+    } as PropOptions<DeviceType>,
+  },
+})
+</script>

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -26,8 +26,7 @@
       </div>
       <div class="baloon">
         <!-- eslint-disable-next-line prettier/prettier -->
-        <div v-if="message.target == null" class="baloon">
-          {{ message.content }}
+        <div v-if="message.target == null" class="baloon">{{ message.content }}
         </div>
         <div v-else class="baloon">
           <span :style="{ color: 'gray', fontSize: '80%' }"
@@ -76,9 +75,7 @@
         <div v-if="message.iconId == '0'" class="admin-badge">運 営</div>
       </div>
       <!-- eslint-disable-next-line prettier/prettier -->
-      <div class="baloon">
-        {{ `Q. ${message.target.content}\nA. ${message.content}` }}
-      </div>
+      <div class="baloon">{{`Q. ${message.target.content}\nA. ${message.content}`}}</div>
       <div class="comment-timestamp">
         {{ showTimestamp(message.timestamp) }}
       </div>
@@ -93,7 +90,9 @@
         <img :src="icon" alt="" />
       </div>
       <span class="material-icons"> thumb_up </span>
-      <div class="text">{{ message.target.content | reactionTargetText }}</div>
+      <div class="long-text">
+        {{ message.target.content }}
+      </div>
       <div class="comment-timestamp">
         {{ showTimestamp(message.timestamp) }}
       </div>
@@ -119,12 +118,6 @@ import { ChatItemPropType } from '~/models/contents'
 
 export default Vue.extend({
   name: 'Message',
-  filters: {
-    reactionTargetText(text: string) {
-      const maxText = 20
-      return text.length > maxText ? text.slice(0, maxText) + '...' : text
-    },
-  },
   props: {
     message: {
       type: Object,

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -93,13 +93,7 @@
         <img :src="icon" alt="" />
       </div>
       <span class="material-icons"> thumb_up </span>
-<<<<<<< HEAD
       <div class="text">{{ message.target.content | reactionTargetText }}</div>
-=======
-      <div class="long-text">
-        {{ message.target.content }}
-      </div>
->>>>>>> 254e8411d16821ed08b12f7786b2daa989a8f8ca
       <div class="comment-timestamp">
         {{ showTimestamp(message.timestamp) }}
       </div>

--- a/app/front/components/TextArea.vue
+++ b/app/front/components/TextArea.vue
@@ -20,7 +20,7 @@
       </button>
     </div>
     <div class="instruction">
-      <KeyInstruction />
+      <KeyInstruction :device-type="deviceType" />
       <span
         class="text-counter"
         :class="{ over: maxMessageLength < text.length }"
@@ -34,7 +34,7 @@
 </template>
 <script lang="ts">
 import Vue, { PropOptions } from 'vue'
-import { TopicPropType } from '@/models/contents'
+import { TopicPropType, DeviceType } from '@/models/contents'
 import KeyInstruction from '@/components/KeyInstruction.vue'
 
 // Data型
@@ -61,6 +61,10 @@ export default Vue.extend({
       type: Boolean,
       required: true,
     },
+    deviceType: {
+      type: String,
+      default: 'windows',
+    } as PropOptions<DeviceType>,
   },
   data(): DataType {
     return {

--- a/app/front/models/contents.ts
+++ b/app/front/models/contents.ts
@@ -56,3 +56,5 @@ export type Stamp = {
   userId: string
   topicId: string
 }
+
+export type DeviceType = 'windows' | 'mac' | 'smartphone'

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -79,8 +79,12 @@ type ChatData = {
   message: ChatItem[]
 }
 
+type DeviceType = 'windows' | 'mac' | 'smartphone'
+
 // Data型
 type DataType = {
+  // OS判定
+  device: DeviceType
   // 管理画面
   hamburgerMenu: string
   isDrawer: boolean
@@ -107,6 +111,8 @@ export default Vue.extend({
   },
   data(): DataType {
     return {
+      // OS判定
+      device: 'windows',
       // 管理画面
       hamburgerMenu: 'menu',
       isDrawer: false,
@@ -187,6 +193,20 @@ export default Vue.extend({
         this.topicStates[res.topicId] = 'finished'
       }
     })
+
+    // OS判定
+    const os = window.navigator.userAgent.toLowerCase()
+    if (os.includes('windows nt')) {
+      this.device = 'windows'
+    } else if (os.includes('android')) {
+      this.device = 'smartphone'
+    } else if (os.includes('iphone') || os.includes('ipad')) {
+      this.device = 'smartphone'
+    } else if (os.includes('mac os x')) {
+      this.device = 'mac'
+    } else {
+      this.device = 'windows'
+    }
   },
   methods: {
     // 管理画面の開閉

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -81,8 +81,6 @@ type ChatData = {
   message: ChatItem[]
 }
 
-type DeviceType = 'windows' | 'mac' | 'smartphone'
-
 // Data型
 type DataType = {
   // OS判定

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -35,6 +35,7 @@
           :favorite-callback-register="favoriteCallbackRegister"
           :my-icon="iconChecked"
           :topic-state="topicStates[chatData.topic.id]"
+          :device-type="deviceType"
           @send-message="sendMessage"
           @send-reaction="sendReaction"
           @send-question="sendQuestion"
@@ -59,6 +60,7 @@ import {
   Stamp,
   Answer,
   Question,
+  DeviceType,
 } from '@/models/contents'
 import {
   AdminBuildRoomResponse,
@@ -84,7 +86,7 @@ type DeviceType = 'windows' | 'mac' | 'smartphone'
 // Data型
 type DataType = {
   // OS判定
-  device: DeviceType
+  deviceType: DeviceType
   // 管理画面
   hamburgerMenu: string
   isDrawer: boolean
@@ -112,7 +114,7 @@ export default Vue.extend({
   data(): DataType {
     return {
       // OS判定
-      device: 'windows',
+      deviceType: 'windows',
       // 管理画面
       hamburgerMenu: 'menu',
       isDrawer: false,
@@ -197,15 +199,15 @@ export default Vue.extend({
     // OS判定
     const os = window.navigator.userAgent.toLowerCase()
     if (os.includes('windows nt')) {
-      this.device = 'windows'
+      this.deviceType = 'windows'
     } else if (os.includes('android')) {
-      this.device = 'smartphone'
+      this.deviceType = 'smartphone'
     } else if (os.includes('iphone') || os.includes('ipad')) {
-      this.device = 'smartphone'
+      this.deviceType = 'smartphone'
     } else if (os.includes('mac os x')) {
-      this.device = 'mac'
+      this.deviceType = 'mac'
     } else {
-      this.device = 'windows'
+      this.deviceType = 'windows'
     }
   },
   methods: {


### PR DESCRIPTION
mac: ⌘+enterで送信
windows: ctrl+enterで送信
smartphone(iphone/ipad/android): 表示しない
それ以外:windowsと同じ