### PR TITLE
[fix] 選択できるテキストの変更、URLに対応

### DIFF
--- a/app/front/assets/scss/common.scss
+++ b/app/front/assets/scss/common.scss
@@ -1,6 +1,7 @@
 body {
   font-family: 'M PLUS 1p', sans-serif;
   //overflow: hidden; // 縦方向は１画面に収める（スクロールさせない）
+  touch-action: manipulation; // ダブルタップによるズームは抑止
 }
 
 .material-icons {

--- a/app/front/assets/scss/heart.scss
+++ b/app/front/assets/scss/heart.scss
@@ -2,6 +2,7 @@
   position: relative;
   display: grid;
   justify-content: center;
+  user-select: none;
 }
 
 .heart-button {

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -333,7 +333,6 @@
       background: rgb(235, 235, 235);
       border: none;
       box-shadow: none;
-      pointer-events: none;
     }
 
     & > .bg-good-icon {
@@ -374,6 +373,14 @@
 
     &.question:hover {
       background: rgb(206, 234, 255);
+    }
+
+    &.answer:hover {
+      background: rgb(255, 233, 237);
+    }
+
+    &.admin:hover {
+      background: rgb(235, 235, 235);
     }
 
     & > .icon-wrapper {

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -257,10 +257,12 @@
       margin-bottom: 0.5rem;
       text-align: end;
       flex: 1;
+      user-select: none;
     }
 
     & > .text-counter {
       font-size: 70%;
+      user-select: none;
     }
 
     & > .over {
@@ -271,6 +273,7 @@
   & > .question-checkbox {
     font-size: 85%;
     margin-left: 0.5em;
+    user-select: none;
   }
 }
 
@@ -292,6 +295,28 @@
 
     &.reaction {
       box-shadow: none;
+      margin-left: 2em;
+      align-items: center;
+
+      & > .icon-wrapper {
+        width: 1.6rem;
+        height: 1.6rem;
+        margin: 0;
+        margin-right: 1em;
+        align-self: center; // NOTE: for safari (yuta-ike)
+      }
+
+      & > .long-text {
+        flex: 1;
+        display: -webkit-box;
+        margin-left: 0.5em;
+        color: $text-gray;
+        font-style: oblique;
+        word-break: break-all;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+        overflow: hidden;
+      }
     }
 
     &.question {
@@ -364,6 +389,7 @@
       display: grid;
       align-items: center;
       position: relative;
+      user-select: none;
 
       & > .question-badge {
         width: 1.25rem;
@@ -402,35 +428,6 @@
       }
     }
 
-    &.reaction {
-      margin-left: 2em;
-      align-items: center;
-
-      & > .icon-wrapper {
-        width: 1.6rem;
-        height: 1.6rem;
-        margin: 0;
-        margin-right: 1em;
-        align-self: center; // NOTE: for safari (yuta-ike)
-      }
-
-      & > .icon-wrapper {
-        margin-right: 1em;
-      }
-
-      & > .long-text {
-        flex: 1;
-        display: -webkit-box;
-        margin-left: 0.5em;
-        color: $text-gray;
-        font-style: oblique;
-        word-break: break-all;
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: 2;
-        overflow: hidden;
-      }
-    }
-
     &.comment > .baloon {
       border-radius: 1.5em;
       width: 100%;
@@ -446,6 +443,7 @@
       bottom: 0;
       right: 0;
       margin: 0;
+      user-select: none;
     }
   }
 

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -435,14 +435,6 @@
       }
     }
 
-    &.comment > .baloon {
-      border-radius: 1.5em;
-      width: 100%;
-      word-break: break-all;
-      z-index: 5;
-      white-space: pre-line;
-    }
-
     & > .comment-timestamp {
       color: $text-gray;
       font-size: 10px;
@@ -508,4 +500,11 @@
       color: $black;
     }
   }
+}
+
+.baloon {
+  border-radius: 1.5em;
+  width: 100%;
+  z-index: 5;
+  white-space: pre-line;
 }

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -501,10 +501,3 @@
     }
   }
 }
-
-.baloon {
-  border-radius: 1.5em;
-  width: 100%;
-  z-index: 5;
-  white-space: pre-line;
-}

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- eslint-disable vue/no-v-html -->
   <div class="chatitem-wrapper">
     <!--Admin Message-->
     <article
@@ -9,7 +10,7 @@
         <img :src="icon" alt="" />
         <div class="admin-badge">運 営</div>
       </div>
-      <div class="baloon">{{ message.content }}</div>
+      <div class="baloon" v-html="autoLink(message.content)"></div>
       <div class="comment-timestamp">
         {{ showTimestamp(message.timestamp) }}
       </div>
@@ -26,13 +27,13 @@
       </div>
       <div class="baloon">
         <!-- eslint-disable-next-line prettier/prettier -->
-        <div v-if="message.target == null" class="baloon">{{ message.content }}
-        </div>
+        <div v-if="message.target == null" class="baloon" v-html="autoLink(message.content)"></div>
         <div v-else class="baloon">
-          <span :style="{ color: 'gray', fontSize: '80%' }"
-            >> {{ message.target.content }}</span
-          >
-          {{ message.content }}
+          <span
+            :style="{ color: 'gray', fontSize: '80%' }"
+            v-html="`>` + autoLink(message.target.content)"
+          ></span>
+          <span v-html="autoLink(message.content)"></span>
         </div>
       </div>
       <div class="comment-timestamp">
@@ -54,7 +55,7 @@
         <div class="question-badge">Q</div>
         <div v-if="message.iconId == '0'" class="admin-badge">運 営</div>
       </div>
-      <div class="baloon">{{ message.content }}</div>
+      <div class="baloon" v-html="autoLink(message.content)"></div>
       <div class="comment-timestamp">
         {{ showTimestamp(message.timestamp) }}
       </div>
@@ -75,7 +76,7 @@
         <div v-if="message.iconId == '0'" class="admin-badge">運 営</div>
       </div>
       <!-- eslint-disable-next-line prettier/prettier -->
-      <div class="baloon">{{`Q. ${message.target.content}\nA. ${message.content}`}}</div>
+      <div class="baloon" v-html="`Q. `+ autoLink(message.target.content) + `\nA.` + autoLink(message.content)"></div>
       <div class="comment-timestamp">
         {{ showTimestamp(message.timestamp) }}
       </div>
@@ -130,6 +131,13 @@ export default Vue.extend({
     },
   },
   methods: {
+    // URLを検出してハイパーリンクに変換
+    autoLink(text: string) {
+      return text.replace(
+        /(https?:\/\/[^\s]*)/g,
+        "<a href='$1', target='_blank'>$1</a>"
+      )
+    },
     clickCard() {
       this.$emit('click-card', this.message)
     },

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -1,5 +1,4 @@
 <template>
-  <!-- eslint-disable vue/no-v-html -->
   <div class="chatitem-wrapper">
     <!--Admin Message-->
     <article
@@ -10,7 +9,7 @@
         <img :src="icon" alt="" />
         <div class="admin-badge">運 営</div>
       </div>
-      <div class="baloon" v-html="autoLink(message.content)"></div>
+      <UrlToLink :text="message.content" />
       <div class="comment-timestamp">
         {{ showTimestamp(message.timestamp) }}
       </div>
@@ -25,16 +24,14 @@
       <div class="icon-wrapper">
         <img :src="icon" alt="" />
       </div>
-      <div class="baloon">
-        <!-- eslint-disable-next-line prettier/prettier -->
-        <div v-if="message.target == null" class="baloon" v-html="autoLink(message.content)"></div>
-        <div v-else class="baloon">
-          <span
-            :style="{ color: 'gray', fontSize: '80%' }"
-            v-html="`>` + autoLink(message.target.content)"
-          ></span>
-          <span v-html="autoLink(message.content)"></span>
-        </div>
+      <div v-if="message.target == null">
+        <UrlToLink :text="message.content" />
+      </div>
+      <div v-else>
+        <span :style="{ color: 'gray', fontSize: '80%' }" @click.stop>
+          <UrlToLink :text="`> ` + message.target.content" />
+        </span>
+        <UrlToLink :text="message.content" />
       </div>
       <div class="comment-timestamp">
         {{ showTimestamp(message.timestamp) }}
@@ -55,7 +52,7 @@
         <div class="question-badge">Q</div>
         <div v-if="message.iconId == '0'" class="admin-badge">運 営</div>
       </div>
-      <div class="baloon" v-html="autoLink(message.content)"></div>
+      <UrlToLink :text="message.content" />
       <div class="comment-timestamp">
         {{ showTimestamp(message.timestamp) }}
       </div>
@@ -75,8 +72,13 @@
         <div class="answer-badge">A</div>
         <div v-if="message.iconId == '0'" class="admin-badge">運 営</div>
       </div>
-      <!-- eslint-disable-next-line prettier/prettier -->
-      <div class="baloon" v-html="`Q. `+ autoLink(message.target.content) + `\nA.` + autoLink(message.content)"></div>
+      <div>
+        Q.
+        <UrlToLink :text="message.target.content" />
+        <br />
+        A.
+        <UrlToLink :text="message.content" />
+      </div>
       <div class="comment-timestamp">
         {{ showTimestamp(message.timestamp) }}
       </div>
@@ -115,10 +117,14 @@
 </template>
 <script lang="ts">
 import Vue, { PropOptions } from 'vue'
+import UrlToLink from '@/components/UrlToLink.vue'
 import { ChatItemPropType } from '~/models/contents'
 
 export default Vue.extend({
   name: 'Message',
+  components: {
+    UrlToLink,
+  },
   props: {
     message: {
       type: Object,
@@ -131,13 +137,6 @@ export default Vue.extend({
     },
   },
   methods: {
-    // URLを検出してハイパーリンクに変換
-    autoLink(text: string) {
-      return text.replace(
-        /(https?:\/\/[^\s]*)/g,
-        "<a href='$1', target='_blank'>$1</a>"
-      )
-    },
     clickCard() {
       this.$emit('click-card', this.message)
     },

--- a/app/front/components/UrlToLink.vue
+++ b/app/front/components/UrlToLink.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <span v-for="(content, i) in text.split(/(https?:\/\/[^\s]*)/)" :key="i">
+      <span v-if="i % 2 === 0">
+        {{ content }}
+      </span>
+      <a v-else :href="content" target="_blank" @click.stop>
+        {{ content }}
+      </a>
+    </span>
+  </div>
+</template>
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'UrlToLink',
+  props: {
+    text: {
+      type: String,
+      required: true,
+    },
+  },
+})
+</script>

--- a/app/front/components/UrlToLink.vue
+++ b/app/front/components/UrlToLink.vue
@@ -2,7 +2,12 @@
   <div>
     <span v-for="(content, i) in text.split(/(https?:\/\/[^\s]*)/)" :key="i">
       <span v-if="i % 2 === 0">
-        {{ content }}
+        <span v-for="(token, j) in content.split(/(\n)/)" :key="j">
+          <span v-if="j % 2 == 0">
+            {{ token }}
+          </span>
+          <br v-else />
+        </span>
       </span>
       <a v-else :href="content" target="_blank" @click.stop>
         {{ content }}

--- a/app/front/layouts/default.vue
+++ b/app/front/layouts/default.vue
@@ -17,7 +17,7 @@ export default {
         href: 'https://fonts.gstatic.com',
       },
     ],
-    title: 'SUSHI CHAT',
+    title: 'sushi-chat',
   },
 }
 </script>

--- a/app/front/nuxt.config.js
+++ b/app/front/nuxt.config.js
@@ -16,17 +16,16 @@ export default {
     },
     meta: [
       { charset: 'utf-8' },
-      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       {
         name: 'viewport',
         content:
-          'width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no',
+          'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1',
       },
       { hid: 'description', name: 'description', content: '' },
       {
         hid: 'og:url',
         property: 'og:url',
-        content: 'https://sushi-chat-liart.vercel.app/',
+        content: 'https://sushi-chat-cyan.vercel.app/',
       },
       {
         hid: 'og:type',

--- a/app/front/nuxt.config.js
+++ b/app/front/nuxt.config.js
@@ -17,6 +17,11 @@ export default {
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+      {
+        name: 'viewport',
+        content:
+          'width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no',
+      },
       { hid: 'description', name: 'description', content: '' },
       {
         hid: 'og:url',

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -378,10 +378,8 @@ export default Vue.extend({
       if (
         window.getSelection()!.getRangeAt(0).endOffset >
         window.getSelection()!.getRangeAt(0).startOffset
-      ) {
+      )
         return
-      }
-      console.log('send reaction: ', message.content)
       const socket = (this as any).socket
       const params: PostChatItemReactionParams = {
         id: getUUID(),

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -378,8 +378,9 @@ export default Vue.extend({
       if (
         window.getSelection()!.getRangeAt(0).endOffset >
         window.getSelection()!.getRangeAt(0).startOffset
-      )
+      ) {
         return
+      }
       console.log('send reaction: ', message.content)
       const socket = (this as any).socket
       const params: PostChatItemReactionParams = {

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -374,6 +374,12 @@ export default Vue.extend({
       })
     },
     sendReaction(message: Message) {
+      // 選択中の文字が存在する場合リアクションしない
+      if (
+        window.getSelection()!.getRangeAt(0).endOffset >
+        window.getSelection()!.getRangeAt(0).startOffset
+      )
+        return
       console.log('send reaction: ', message.content)
       const socket = (this as any).socket
       const params: PostChatItemReactionParams = {


### PR DESCRIPTION
issue #219 
issue #220 

## やったこと
- アイコンやinstructionなどがコピペ範囲に入るのを外した
- ~~user-scalable=noにしてみた(試験的)~~
- touch-action: manipulationにした(効いてなさそう)
- 選択中の文字が存在する場合、クリックしてもリアクションしない
- 全メッセージタイプでURLをハイパーリンクに変換
- URLをクリックした場合リアクションは発火しない
- 改行がうまく表示

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->
