### PR TITLE
Tomokon/setup aws

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/jsLinters/eslint.xml
+++ b/.idea/jsLinters/eslint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EslintConfiguration">
+    <option name="fix-on-save" value="true" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="WebPackConfiguration">
+    <option name="mode" value="DISABLED" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/sushi-chat.iml" filepath="$PROJECT_DIR$/.idea/sushi-chat.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PrettierConfiguration">
+    <option name="myRunOnSave" value="true" />
+    <option name="myRunOnReformat" value="true" />
+  </component>
+</project>

--- a/.idea/sushi-chat.iml
+++ b/.idea/sushi-chat.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/server/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/terraform/.terraform" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -12,3 +12,5 @@ const PORT = process.env.PORT || 7000;
 httpServer.listen(PORT, function () {
   console.log("server listening. Port:" + PORT);
 });
+
+app.get("/", (req, res) => res.send("ok"));

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.39.0"
+  hashes = [
+    "h1:fjlp3Pd3QsTLghNm7TUh/KnEMM2D3tLb7jsDLs8oWUE=",
+    "zh:2014b397dd93fa55f2f2d1338c19e5b2b77b025a76a6b1fceea0b8696e984b9c",
+    "zh:23d59c68ab50148a0f5c911a801734e9934a1fccd41118a8efb5194135cbd360",
+    "zh:412eab41d4934ca9c47083faa128e4cd585c3bb44ad718e40d67091aebc02f4e",
+    "zh:4b75e0a259b56d97e66b7d69f3f25bd4cc7be2440c0fe35529f46de7d40a49d3",
+    "zh:694a32519dcca5bd8605d06481d16883d55160d97c1f4039deb13c6ca8de8427",
+    "zh:6a0bcef43c2d9a97aeaaac3c5d1d6728dc2464a51a014f118c691c79029d0903",
+    "zh:6d78fc7c663247ca2a80f276008dcdafece4cac75e2639bbce188c08b796040a",
+    "zh:78f846a505d7b64b67feed1527d4d2b40130dadaf8e3112113685e148f49b156",
+    "zh:881bc969432d3ef6ec70f5a762c3415e037904338579b0a360c6818b74d26e59",
+    "zh:96c1ca80c1d693a3eef80489adb45c076ee8e6878e461d6c29b05388d4b95f48",
+    "zh:9be5fa342272586fc6e319e20f21c0c5c801b05dcf7d59e473ad0882c9ecfa70",
+  ]
+}

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,0 +1,68 @@
+resource "aws_instance" "main" {
+  ami                    = var.ami.amazon-linux-2
+  instance_type          = "t2.micro"
+  subnet_id              = aws_subnet.public_a.id
+  vpc_security_group_ids = [aws_security_group.public_instance.id]
+  user_data              = file("./user_data.tpl")
+  key_name               = var.key-pair
+  placement_group        = ""
+
+  tags = {
+    Name    = "${var.project}-ec2-instance"
+    project = var.project
+  }
+}
+
+resource "aws_alb_target_group_attachment" "main" {
+  target_group_arn = aws_lb_target_group.main.arn
+  target_id        = aws_instance.main.id
+  port             = 80
+}
+
+resource "aws_security_group" "public_instance" {
+  description = "This is a security group for API server for sushi-chat app. It allows http and https from alb, and ssh from admin."
+  vpc_id = aws_vpc.main.id
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = [var.cidr_default_gateway.ipv4] #tfsec:ignore:AWS009
+    ipv6_cidr_blocks = [var.cidr_default_gateway.ipv6] #tfsec:ignore:AWS009
+  }
+
+  tags = {
+    Name    = "${var.project}-sg-public-instance"
+    project = var.project
+  }
+}
+
+resource "aws_security_group_rule" "allow_ssh" {
+  description = "This allow ssh to public instance from admin."
+  security_group_id = aws_security_group.public_instance.id
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = [var.my_global_ip]
+}
+
+resource "aws_security_group_rule" "allow_http" {
+  description = "This allows http from alb."
+  security_group_id        = aws_security_group.public_instance.id
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.public_alb.id
+}
+
+resource "aws_security_group_rule" "allow_https" {
+  description = "This allows https from alb."
+  security_group_id        = aws_security_group.public_instance.id
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.public_alb.id
+}

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -1,0 +1,99 @@
+#tfsec:ignore:AWS005
+resource "aws_lb" "main" {
+  load_balancer_type = "application"
+  name               = "${var.project}-alb"
+  security_groups    = [aws_security_group.public_alb.id]
+  subnets            = [aws_subnet.public_a.id, aws_subnet.public_c.id]
+
+  tags = {
+    Name    = "${var.project}-alb"
+    project = var.project
+  }
+}
+
+resource "aws_security_group" "public_alb" {
+  description = "This is a security group for public alb for API servers of sushi-chat app."
+  name   = "${var.project}-sg-alb"
+  vpc_id = aws_vpc.main.id
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = [var.cidr_default_gateway.ipv4] #tfsec:ignore:AWS009
+    ipv6_cidr_blocks = [var.cidr_default_gateway.ipv6] #tfsec:ignore:AWS009
+  }
+
+  tags = {
+    Name    = "${var.project}-sg-alb"
+    project = var.project
+  }
+}
+
+resource "aws_security_group_rule" "public_http" {
+  description = "This allows http from internet."
+  security_group_id = aws_security_group.public_alb.id
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks      = [var.cidr_default_gateway.ipv4] #tfsec:ignore:AWS006
+  ipv6_cidr_blocks = [var.cidr_default_gateway.ipv6] #tfsec:ignore:AWS006
+}
+
+resource "aws_security_group_rule" "public_https" {
+  description = "This allows https from internet."
+  security_group_id = aws_security_group.public_alb.id
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks      = [var.cidr_default_gateway.ipv4] #tfsec:ignore:AWS006
+  ipv6_cidr_blocks = [var.cidr_default_gateway.ipv6] #tfsec:ignore:AWS006
+}
+
+resource "aws_lb_target_group" "main" {
+  name        = "${var.project}-target-group"
+  vpc_id      = aws_vpc.main.id
+  port        = 80
+  protocol    = "HTTP"
+  target_type = "instance"
+
+  health_check {
+    port = 80
+    path = "/"
+  }
+
+  tags = {
+    Name    = "${var.project}-target-group"
+    project = var.project
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.main.arn
+  certificate_arn   = aws_acm_certificate.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.main.arn
+  }
+}
+
+resource "aws_lb_listener" "redirect_http_to_https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,0 +1,8 @@
+output "instance_public_dns" {
+  value = aws_instance.main.public_dns
+}
+
+output "rds_endpoint" {
+  value = aws_db_instance.main.endpoint
+}
+

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,0 +1,49 @@
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.project}-db-subnet-group"
+  subnet_ids = [aws_subnet.private_a.id, aws_subnet.private_c.id]
+
+  tags = {
+    Name    = "${var.project}-db-subnet-group"
+    project = var.project
+  }
+}
+
+resource "aws_security_group" "db" {
+  description = "For persistent DB. Several events, e.g. entering room, chats and reactions, are stored."
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name    = "${var.project}-sg-db"
+    project = var.project
+  }
+}
+
+resource "aws_security_group_rule" "allow_private_postgres_access" {
+  description = "This allows access to postgres from public instance."
+  security_group_id        = aws_security_group.db.id
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.public_instance.id
+}
+
+resource "aws_db_instance" "main" {
+  identifier             = "${var.project}-db-instance"
+  engine                 = "postgres"
+  engine_version         = "12.5"
+  instance_class         = "db.t2.micro"
+  name                   = var.rds.db_name
+  username               = var.rds.user
+  password               = var.rds.password
+  allocated_storage      = 10
+  storage_type           = "gp2"
+  vpc_security_group_ids = [aws_security_group.db.id]
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  skip_final_snapshot    = true
+
+  tags = {
+    Name    = "${var.project}-db-instance"
+    project = var.project
+  }
+}

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,0 +1,49 @@
+data "aws_route53_zone" "main" {
+  name         = var.domain
+  private_zone = false
+}
+
+resource "aws_route53_record" "main" {
+  name    = var.domain
+  type    = "A"
+  zone_id = data.aws_route53_zone.main.id
+
+  alias {
+    evaluate_target_health = false
+    name                   = aws_lb.main.dns_name
+    zone_id                = aws_lb.main.zone_id
+  }
+}
+
+resource "aws_acm_certificate" "main" {
+  domain_name       = var.domain
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "validation" {
+  zone_id    = data.aws_route53_zone.main.zone_id
+  ttl        = 60
+  depends_on = [aws_acm_certificate.main]
+
+  for_each = {
+    for dvo in aws_acm_certificate.main.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+}
+
+resource "aws_acm_certificate_validation" "main" {
+  certificate_arn         = aws_acm_certificate.main.arn
+  validation_record_fqdns = [for record in aws_route53_record.validation : record.fqdn]
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "sushi-chat-terraform-181562662531"
+    key    = "dev/terraform.tfstate"
+    region = "ap-northeast-1"
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+}

--- a/terraform/user_data.tpl
+++ b/terraform/user_data.tpl
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+yum -y update
+
+# Install and setup nginx
+amazon-linux-extras install -y nginx1
+cat - << EOL > /etc/nginx/conf.d/server.conf
+server {
+    listen       80;
+    server_name  sushi-chat.tk; # Should change to real hostname
+
+    proxy_set_header Host \$host;
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header X-Forwarded-Host \$host;
+    proxy_set_header X-Forwarded-Server \$host;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+
+    location / {
+        proxy_pass http://localhost:7000;
+    	proxy_http_version 1.1;
+    	proxy_set_header Upgrade \$http_upgrade;
+    	proxy_set_header Connection "upgrade";
+    }
+}
+EOL
+systemctl start nginx
+systemctl enable nginx
+
+# Install node.js and npm
+curl --silent --location https://rpm.nodesource.com/setup_14.x | bash -
+yum -y install nodejs
+npm install -g npm
+
+# Install git
+yum -y install git
+
+# Download app source
+mkdir /app
+chmod 705 /app
+git clone https://github.com/KoukiNAGATA/sushi-chat.git /app
+
+# Build and start app
+cd /app/server
+npm install
+npm run build
+npm run start & # listen on localhost:7000

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,73 @@
+variable "project" {
+  type = string
+}
+
+variable "my_global_ip" {
+  type = string
+}
+
+variable "region" {
+  type    = string
+  default = "ap-northeast-1"
+}
+
+variable "az" {
+  type = map(string)
+  default = {
+    a = "ap-northeast-1a"
+    c = "ap-northeast-1c"
+    d = "ap-northeast-1d"
+  }
+}
+
+variable "cidr_default_gateway" {
+  type = map(string)
+  default = {
+    ipv4 = "0.0.0.0/0"
+    ipv6 = "::/0"
+  }
+}
+
+variable "vpc_cidr" {
+  type = string
+}
+
+variable "subnet_cidr" {
+  type = map(map(string))
+  default = {
+    public = {
+      a = ""
+      c = ""
+      d = ""
+    }
+    private = {
+      a = ""
+      c = ""
+      d = ""
+    }
+  }
+}
+
+variable "ami" {
+  type = map(string)
+  default = {
+    amazon-linux-2 = "ami-06098fd00463352b6"
+  }
+}
+
+variable "key-pair" {
+  type = string
+}
+
+variable "rds" {
+  type = map(string)
+  default = {
+    user     = ""
+    db_name  = ""
+    password = ""
+  }
+}
+
+variable "domain" {
+  type = string
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,93 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+
+  tags = {
+    Name    = "${var.project}-vpc"
+    project = var.project
+  }
+}
+
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.subnet_cidr.public.a
+  availability_zone       = var.az.a
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name    = "${var.project}-subnet-public-a"
+    project = var.project
+  }
+}
+
+resource "aws_subnet" "public_c" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.subnet_cidr.public.c
+  availability_zone       = var.az.c
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name    = "${var.project}-subnet-public-c"
+    project = var.project
+  }
+}
+
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.subnet_cidr.private.a
+  availability_zone = var.az.a
+
+  tags = {
+    Name    = "${var.project}-subnet-private-a"
+    project = var.project
+  }
+}
+
+resource "aws_subnet" "private_c" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.subnet_cidr.private.c
+  availability_zone = var.az.c
+
+  tags = {
+    Name    = "${var.project}-subnet-private-c"
+    project = var.project
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name    = "${var.project}-igw"
+    project = var.project
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = var.cidr_default_gateway.ipv4
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  route {
+    ipv6_cidr_block = var.cidr_default_gateway.ipv6
+    gateway_id      = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name    = "${var.project}-route-table-public"
+    project = var.project
+  }
+}
+
+resource "aws_route_table_association" "public_a" {
+  route_table_id = aws_route_table.public.id
+  subnet_id      = aws_subnet.public_a.id
+}
+
+resource "aws_route_table_association" "public_c" {
+  route_table_id = aws_route_table.public.id
+  subnet_id      = aws_subnet.public_c.id
+}


### PR DESCRIPTION
issue #xxx

## やったこと
- Terraformによるインフラリソースのコード化（手元でAWSの個人アカウントを用いた検証をして動きました）
- AWSの設計上ヘルスチェック用のエンドポイントが必要だったので、`/`のGETのエンドポイントを追加しました。

## やっていないこと
- マルチサーバー構成のインフラ環境構築

<!--
## スクリーンショット
-->

## 動作確認手順
やるとしたら以下のようにやると言う話なので、レビュワーが実際にやる必要ははないです。
- Terraformとaws cliのインストールをする
- `aws configure`で適切な権限を持つユーザーのcredentialを設定する
- 使うAWSアカウントのS3バケットに、`terraform.tf`に記載してあるbucket名と同じバケットを作成する。(S3のバケット名はグローバルに一意なので、バケット名は書き換えて使う必要がある。)
- `terraform init`、`terraform apply`でインフラリソースの構築を行う

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
- .ideaディレクトリはJetBrains製品の設定ファイルなので気にしなくて大丈夫です。
- SSL化するのに独自ドメインが必要だったので一時的に無料ドメイン(`sushi-chat.tk`)を使っていますが、そこは本番用のドメインに置き換える予定です。