### PR TITLE
Botの質問一覧のメッセージが表示されないバグを修正

### DIFF
--- a/app/front/components/SettingPage.vue
+++ b/app/front/components/SettingPage.vue
@@ -133,6 +133,7 @@ export default Vue.extend({
         confirm('本当にこのトピックを終了しますか？この操作は取り消せません')
       ) {
         this.topicStates[topicId]! = 'finished'
+        this.$emit('change-topic-state', topicId, 'closed')
       }
     },
     clickNextTopicButton() {

--- a/server/src/models/room.ts
+++ b/server/src/models/room.ts
@@ -132,7 +132,7 @@ class RoomClass {
       throw new Error("[sushi-chat-server] Topic does not exists.");
     }
     if (params.type === "OPEN") {
-      // 現在activeであるトピックをCfinishedにし、指定したトピックをopenにする
+      // 現在activeであるトピックをfinishedにし、指定したトピックをopenにする
       const currentActiveTopic = this.activeTopic;
       if (currentActiveTopic != null) {
         currentActiveTopic.state = "finished";


### PR DESCRIPTION
issue #179 

## やったこと
- トピック終了時の処理を関数に切り出し
- 質問をまとめて表示する機能を追加
- ついでに回答済みの質問には`[回答済み]`のラベルを追加

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
