### PR TITLE
複数管理者に対応

### DIFF
--- a/app/front/components/SettingPage.vue
+++ b/app/front/components/SettingPage.vue
@@ -7,15 +7,14 @@
         </div>
         <div class="room-info">
           <div class="room-title">
-            <p>{{ room.title }}</p>
+            <p>{{ title }}</p>
           </div>
           <div class="room-url">
-            <span>{{ baseUrl }}?roomId={{ room.id }}</span>
+            <span>{{ shareUrl }}</span>
             <button
               class="material-icons copy-button"
               :disabled="
-                room.topics.findIndex((t) => topicStates[t.id] === 'active') ==
-                null
+                topics.findIndex((t) => topicStates[t.id] === 'active') == null
               "
               @click="writeToClipboard"
             >
@@ -36,7 +35,7 @@
 
       <div class="topic-list">
         <div
-          v-for="(topic, index) in room.topics"
+          v-for="(topic, index) in topics"
           :key="topic.id"
           class="topic"
           :class="topicStates[topic.id]"
@@ -78,15 +77,23 @@
 
 <script lang="ts">
 import Vue, { PropOptions } from 'vue'
-import { TopicStatesPropType, Room } from '@/models/contents'
+import { TopicStatesPropType, Topic } from '@/models/contents'
 
 export default Vue.extend({
   name: 'SettingPage',
   props: {
-    room: {
-      type: Object,
+    roomId: {
+      type: String,
       required: true,
-    } as PropOptions<Room>,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    topics: {
+      type: Array,
+      required: true,
+    } as PropOptions<Topic[]>,
     topicStates: {
       type: Object,
       required: true,
@@ -100,8 +107,8 @@ export default Vue.extend({
     icon(): { icon: string } {
       return ICONS[this.myIconId]?.icon ?? ICONS[0].icon
     },
-    baseUrl() {
-      return String(location.href).replace('?user=admin', '')
+    shareUrl() {
+      return `${location.origin}?roomId=${encodeURIComponent(this.roomId)}`
     },
     playOrPause() {
       return function (topicState: string) {
@@ -117,7 +124,7 @@ export default Vue.extend({
   },
   methods: {
     writeToClipboard() {
-      navigator.clipboard.writeText(this.baseUrl + '?roomId=' + this.room.id)
+      navigator.clipboard.writeText(this.shareUrl)
     },
     clickPlayPauseButton(topicId: string) {
       if (this.topicStates[topicId] === 'active') {
@@ -137,7 +144,7 @@ export default Vue.extend({
     },
     clickNextTopicButton() {
       // アクティブなトピックを探す
-      const currentActiveTopicIndex = this.room.topics.findIndex(
+      const currentActiveTopicIndex = this.topics.findIndex(
         (t) => this.topicStates[t.id] === 'active'
       )
 
@@ -145,7 +152,7 @@ export default Vue.extend({
         return
       }
 
-      const nextTopic = this.room.topics?.[currentActiveTopicIndex + 1]
+      const nextTopic = this.topics?.[currentActiveTopicIndex + 1]
 
       if (nextTopic != null) {
         this.$emit('change-topic-state', nextTopic.id, 'active')


### PR DESCRIPTION
issue #225 #221 

## やったこと
- `/?user=admin&roomId=XXX`でアクセスした場合、既存のルームに管理者として入るように変更
  - index.vueで、roomIdがついている場合の処理を追加
  - SettingPage.vueで、roomではなくサーバーからの返り値を参照するように変更

## やっていないこと
- サーバー側の対応が必要なバグ修正

<!--
## スクリーンショット
-->


## 動作確認手順
- `http://localhost:3000/?user=admin`にアクセスしルームを立てる
- ルームが立つと自動でURLにroomIdが付与される（`http://localhost:3000/?user=admin&roomId=XXX`）ので、このURLをコピペして違うウィンドウで開く（2人目の管理者として入れる）

<!--
## 困っていること
-->


## 既知のバグ（別PRで対応するものなど）
- 後から入った管理者はルーム名が見えない（サーバー側の対応が必要なので保留）
- 「ルームをオープンする」のボタンは、ルームを作った管理者しか押せない（サーバー側の対応が必要なので保留）

## 参考リンク・補足など