### PR TITLE
盛り上がりグラフを開閉可能にした

### DIFF
--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -113,6 +113,61 @@
     .list-complete-leave-active {
       position: absolute;
     }
+
+    & > .graph-wrapper {
+      margin: 2px 16px 4px 16px;
+      border-top: 2px solid $gray;
+      text-align: end;
+
+      & > .close-button {
+        border: none;
+        background: transparent;
+      }
+
+      & > .graph-action-area {
+        text-align: end;
+        padding-top: 4px;
+        margin-bottom: -8px;
+        display: flex;
+        justify-content: flex-end;
+
+        & > .close-button {
+          border: none;
+          background: transparent;
+          border-radius: 100%;
+          width: 32px;
+          height: 32px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          &:hover {
+            background: rgba(0, 0, 0, 0.021);
+          }
+        }
+      }
+    }
+
+    & > .show-graph-button {
+      text-align: center;
+      border: none;
+      background: $gray;
+      border-radius: 999px;
+      margin: 4px 54px 4px 16px;
+      padding: 8px 0;
+      font-size: 0.8rem;
+      transition: all 0.3s;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+
+      & > .toggle-icon {
+        margin-left: 8px;
+      }
+
+      &:hover {
+        background: rgb(206, 205, 205);
+      }
+    }
   }
 
   & > .stamp-zone {

--- a/app/front/components/AnalysisGraph.vue
+++ b/app/front/components/AnalysisGraph.vue
@@ -1,10 +1,6 @@
 <template>
   <div class="chatitem-wrapper comment">
     <div class="comment admin">
-      <div class="icon-wrapper">
-        <img :src="icon" alt="" />
-        <div class="admin-badge">運 営</div>
-      </div>
       <ChartLine
         :chart-data="chartData"
         :options="chartOption"

--- a/app/front/components/AnalysisGraph.vue
+++ b/app/front/components/AnalysisGraph.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="chatitem-wrapper comment">
+  <div class="chatitem-wrapper">
     <div class="comment admin">
       <ChartLine
         :chart-data="chartData"
@@ -70,7 +70,7 @@ export default Vue.extend({
       // チャートのスタイル: <canvas>のstyle属性として設定
       chartStyles: {
         height: 'auto',
-        width: '80%',
+        width: '100%',
       },
       icon: require('@/assets/img/tea.png'),
     }

--- a/app/front/components/ChatRoom.vue
+++ b/app/front/components/ChatRoom.vue
@@ -25,14 +25,24 @@
               @click-reply="selectedChatItem = message"
             />
           </div>
-          <div
-            v-if="topicState === 'finished'"
-            :key="chatData.topic.id"
-            class="list-complete-item"
-          >
-            <AnalysisGraph :chat-data="chatData" />
-          </div>
         </transition-group>
+        <div v-if="showGraph" class="graph-wrapper">
+          <div class="graph-action-area" style="text-align: end">
+            <button class="close-button" @click="showGraph = false">
+              <XIcon></XIcon>
+            </button>
+          </div>
+          <AnalysisGraph :chat-data="chatData" />
+        </div>
+        <button
+          v-if="topicState === 'finished' && !showGraph"
+          :key="chatData.topic.id"
+          class="show-graph-button"
+          @click="showGraph = true"
+        >
+          盛り上がりグラフを見る
+          <ChevronUpIcon class="toggle-icon" size="14"></ChevronUpIcon>
+        </button>
       </div>
       <div class="stamp-zone">
         <FavoriteButton
@@ -75,6 +85,7 @@ import MessageComponent from '@/components/Message.vue'
 import TextArea from '@/components/TextArea.vue'
 import FavoriteButton from '@/components/FavoriteButton.vue'
 import exportText from '@/utils/textExports'
+import { XIcon, ChevronUpIcon } from 'vue-feather-icons'
 import AnalysisGraph from './AnalysisGraph.vue'
 
 type ChatDataPropType = {
@@ -93,6 +104,7 @@ type FavoriteCallbackRegisterPropType = {
 type DataType = {
   isNotify: boolean
   selectedChatItem: ChatItem | null
+  showGraph: boolean
 }
 
 export default Vue.extend({
@@ -103,6 +115,8 @@ export default Vue.extend({
     TextArea,
     FavoriteButton,
     AnalysisGraph,
+    XIcon,
+    ChevronUpIcon,
   },
   props: {
     chatData: {
@@ -139,6 +153,7 @@ export default Vue.extend({
     return {
       isNotify: false,
       selectedChatItem: null,
+      showGraph: false,
     }
   },
   computed: {


### PR DESCRIPTION
## やったこと
- 盛り上がりグラフをボタンで開閉可能にした
- 盛り上がりグラフの吹き出しから運営アイコンを削除した（違和感があったので）


<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
