### PR TITLE
[fix]ホバー時にコメント数が見えないように

### DIFF
--- a/app/front/components/AnalysisGraph.vue
+++ b/app/front/components/AnalysisGraph.vue
@@ -66,6 +66,9 @@ export default Vue.extend({
             },
           ],
         },
+        tooltips: {
+          mode: undefined,
+        },
       },
       // チャートのスタイル: <canvas>のstyle属性として設定
       chartStyles: {


### PR DESCRIPTION
## やったこと
グラフホバー時にコメント数が見えていたので、無効にした

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
