### PR TITLE
[fix] 文字数制限の表示を変更

### DIFF
--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -318,10 +318,12 @@
     & > .text-counter {
       font-size: 70%;
       user-select: none;
+      display: none;
     }
 
     & > .over {
       color: red;
+      display: inline;
     }
   }
 

--- a/app/front/components/TextArea.vue
+++ b/app/front/components/TextArea.vue
@@ -24,7 +24,7 @@
       <span
         class="text-counter"
         :class="{ over: maxMessageLength < text.length }"
-        >文字数をオーバーしています。 {{ 300 - text.length }}</span
+        >文字数をオーバーしています。 {{ maxMessageLength - text.length }}</span
       >
     </div>
     <label class="question-checkbox">

--- a/app/front/components/TextArea.vue
+++ b/app/front/components/TextArea.vue
@@ -24,7 +24,7 @@
       <span
         class="text-counter"
         :class="{ over: maxMessageLength < text.length }"
-        >{{ text.length }}</span
+        >文字数をオーバーしています。 {{ 300 - text.length }}</span
       >
     </div>
     <label class="question-checkbox">


### PR DESCRIPTION
300字以内なら非表示
文字数オーバーでオーバーした文字数が赤色(ツイッター風にマイナス表示)

issue #242 

## やったこと

<!--
## やっていないこと
-->

## スクリーンショット
<img width="440" alt="Screen Shot 2021-06-08 at 16 17 30" src="https://user-images.githubusercontent.com/38304075/121140740-2ad0fc00-c875-11eb-9c6b-6fa2ebf9cb0c.png">


<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
