### PR TITLE
UI周りの修正

### DIFF
--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -83,7 +83,7 @@
   display: flex;
   border-top: 2px solid $gray;
   position: relative;
-  overflow-y: scroll;
+  overflow-y: hidden;
 
   & > .text-zone {
     flex: 1;
@@ -423,6 +423,11 @@
 
     &.comment {
       cursor: pointer;
+
+      &.admin {
+        cursor: default;
+      }
+
       &:hover {
         background: rgb(245, 245, 245);
       }
@@ -508,9 +513,11 @@
     top: 1rem;
     right: 0rem;
     border-radius: 100%;
+    border: none;
+    background: transparent;
 
     & > .material-icons {
-      font-size: 32px;
+      font-size: 28px;
       color: $gray;
       &:hover {
         color: $text-gray;
@@ -526,13 +533,6 @@
       &:active {
         color: $pink;
       }
-    }
-
-    &:hover {
-      background: $hover-button-background;
-    }
-    &:active {
-      background: $active-button-background;
     }
   }
 }

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -73,11 +73,13 @@
         <div v-if="message.iconId == '0'" class="admin-badge">運 営</div>
       </div>
       <div>
-        Q.
-        <UrlToLink :text="message.target.content" />
-        <br />
-        A.
-        <UrlToLink :text="message.content" />
+        <span>
+          <UrlToLink
+            :text="'Q. ' + message.target.content"
+            :style="{ color: 'gray', fontSize: '80%' }"
+          />
+        </span>
+        <UrlToLink :text="'A. ' + message.content" />
       </div>
       <div class="comment-timestamp">
         {{ showTimestamp(message.timestamp) }}
@@ -101,7 +103,7 @@
       </div>
     </article>
     <!--Reply Badge-->
-    <div
+    <button
       v-if="message.type != 'reaction' && message.iconId != '0'"
       class="reply-icon"
       @click="clickReply"
@@ -112,7 +114,7 @@
       >
         reply
       </span>
-    </div>
+    </button>
   </div>
 </template>
 <script lang="ts">


### PR DESCRIPTION
## やったこと
デザイン修正いくつか
- chat-areaをスクロール不可にした（~~多分Windowsでスクロールバー2重に表示されてた原因~~じゃなかったっぽい）
- 吹き出し横のリプライボタンをdivからbuttonに変更&スタイルを調整（ホバー時の背景色の変化を廃止）
- 回答吹き出しのデザインを調整（改行の削除、質問文のフォントを小さくするなど）
![image](https://user-images.githubusercontent.com/38308823/121147348-bea5c680-c87b-11eb-854d-1273147f3162.png)

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など