### PR TITLE
スクロール可能要素がダブってるのを修正

### DIFF
--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -90,6 +90,7 @@
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
+    overflow-y: hidden;
 
     & > .scrollable {
       scroll-snap-type: y mandatory;

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -90,7 +90,6 @@
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
-    overflow-y: scroll;
 
     & > .scrollable {
       scroll-snap-type: y mandatory;


### PR DESCRIPTION
issue #xxx

## やったこと
スクロール可能要素が入れ子上に2つ存在していたため、片方をスクロール不可にした。

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
