### PR TITLE
ユーザー情報のVuex移行

### DIFF
--- a/app/front/components/ChatRoom.vue
+++ b/app/front/components/ChatRoom.vue
@@ -3,7 +3,6 @@
     <TopicHeader
       :title="topicIndex + '. ' + chatData.topic.title"
       :topic-state="topicState"
-      :is-admin="isAdmin"
       @topic-activate="clickTopicActivate"
       @download="clickDownload"
     />
@@ -112,10 +111,6 @@ export default Vue.extend({
       type: String,
       required: true,
     } as PropOptions<TopicState>,
-    isAdmin: {
-      type: Boolean,
-      default: false,
-    },
   },
   data(): DataType {
     return {

--- a/app/front/components/ChatRoom.vue
+++ b/app/front/components/ChatRoom.vue
@@ -54,7 +54,6 @@
     </div>
     <TextArea
       :topic="chatData.topic"
-      :my-icon="myIcon"
       :disabled="isNotStartedTopic"
       @submit="clickSubmit"
     />
@@ -109,10 +108,6 @@ export default Vue.extend({
       type: Function,
       required: true,
     } as PropOptions<FavoriteCallbackRegisterPropType>,
-    myIcon: {
-      type: Number,
-      required: true,
-    },
     topicState: {
       type: String,
       required: true,

--- a/app/front/components/SelectIconModal.vue
+++ b/app/front/components/SelectIconModal.vue
@@ -9,7 +9,7 @@
           v-for="(icon, index) in icons"
           :key="index"
           :class="{
-            'icon-selected': iconChecked == index,
+            'icon-selected': myIconId == index,
             'icon-shari': index === 10,
           }"
           class="icon-box"
@@ -20,7 +20,7 @@
       </div>
       <div class="modal-actions">
         <button
-          :disabled="iconChecked < 0"
+          :disabled="myIconId < 0"
           type="button"
           class="primary-button"
           @click="hideModal"
@@ -35,6 +35,7 @@
 <script lang="ts">
 import Vue, { PropOptions } from 'vue'
 import { IconsPropType } from '@/models/contents'
+import { UserItemStore } from '~/store'
 
 export default Vue.extend({
   name: 'SelectIconModal',
@@ -43,9 +44,10 @@ export default Vue.extend({
       type: Array,
       required: true,
     } as PropOptions<IconsPropType>,
-    iconChecked: {
-      type: Number,
-      required: true,
+  },
+  computed: {
+    myIconId() {
+      return UserItemStore.userItems.myIconId
     },
   },
   methods: {

--- a/app/front/components/SettingPage.vue
+++ b/app/front/components/SettingPage.vue
@@ -79,6 +79,7 @@
 <script lang="ts">
 import Vue, { PropOptions } from 'vue'
 import { TopicStatesPropType, Room } from '@/models/contents'
+import { UserItemStore } from '~/store'
 
 export default Vue.extend({
   name: 'SettingPage',
@@ -91,14 +92,13 @@ export default Vue.extend({
       type: Object,
       required: true,
     } as PropOptions<TopicStatesPropType>,
-    myIconId: {
-      type: Number,
-      required: true,
-    },
   },
   computed: {
+    myIconId() {
+      return UserItemStore.userItems.myIconId + 1
+    },
     icon(): { icon: string } {
-      return ICONS[this.myIconId]?.icon ?? ICONS[0].icon
+      return ICONS[UserItemStore.userItems.myIconId]?.icon ?? ICONS[0].icon
     },
     baseUrl() {
       return String(location.href).replace('?user=admin', '')

--- a/app/front/components/TextArea.vue
+++ b/app/front/components/TextArea.vue
@@ -53,10 +53,6 @@ export default Vue.extend({
       type: Object,
       required: true,
     } as PropOptions<TopicPropType>,
-    myIcon: {
-      type: Number,
-      required: true,
-    },
     disabled: {
       type: Boolean,
       required: true,

--- a/app/front/components/TopicHeader.vue
+++ b/app/front/components/TopicHeader.vue
@@ -26,6 +26,7 @@
 import Vue, { PropOptions } from 'vue'
 import { TopicState } from '@/models/contents'
 import { DownloadIcon, ZapIcon } from 'vue-feather-icons'
+import { UserItemStore } from '~/store'
 
 export default Vue.extend({
   name: 'TopicHeader',
@@ -38,14 +39,15 @@ export default Vue.extend({
       type: String,
       required: true,
     },
-    isAdmin: {
-      type: Boolean,
-      required: true,
-    },
     topicState: {
       type: String,
       required: true,
     } as PropOptions<TopicState>,
+  },
+  computed: {
+    isAdmin(): boolean {
+      return UserItemStore.userItems.isAdmin
+    },
   },
   methods: {
     clickTopicActivate() {

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -16,7 +16,6 @@
       <SelectIconModal
         v-if="!isAdmin"
         :icons="icons"
-        :icon-checked="iconChecked"
         @click-icon="clickIcon"
         @hide-modal="hide"
       />
@@ -24,7 +23,6 @@
         v-if="isDrawer && isAdmin"
         :room="room"
         :topic-states="topicStates"
-        :my-icon-id="iconChecked + 1"
         @change-topic-state="changeTopicState"
       />
       <div v-for="(chatData, index) in chatDataList" :key="index">
@@ -33,7 +31,6 @@
           :is-admin="isAdmin"
           :chat-data="chatData"
           :favorite-callback-register="favoriteCallbackRegister"
-          :my-icon="iconChecked"
           :topic-state="topicStates[chatData.topic.id]"
           @send-stamp="sendFavorite"
           @topic-activate="changeActiveTopic"
@@ -52,7 +49,7 @@ import ChatRoom from '@/components/ChatRoom.vue'
 import CreateRoomModal from '@/components/CreateRoomModal.vue'
 import SelectIconModal from '@/components/SelectIconModal.vue'
 import socket from '~/utils/socketIO'
-import { ChatItemStore, DeviceStore } from '~/store'
+import { ChatItemStore, DeviceStore, UserItemStore } from '~/store'
 
 // 1つのトピックと、そのトピックに関するメッセージ一覧を含むデータ構造
 type ChatData = {
@@ -73,7 +70,6 @@ type DataType = {
   // ユーザー関連
   isAdmin: boolean
   icons: any
-  iconChecked: number
 }
 Vue.use(VModal)
 export default Vue.extend({
@@ -109,7 +105,6 @@ export default Vue.extend({
         { url: require('@/assets/img/sushi_uni.png') },
         { url: require('@/assets/img/sushi_syari.png') },
       ],
-      iconChecked: -1,
     }
   },
   computed: {
@@ -260,7 +255,7 @@ export default Vue.extend({
     // modalを消し、topic作成
     hide(): any {
       this.$modal.hide('sushi-modal')
-      this.enterRoom(this.iconChecked + 1)
+      this.enterRoom(UserItemStore.userItems.myIconId + 1)
     },
     // ルーム入室
     enterRoom(iconId: number) {
@@ -285,7 +280,7 @@ export default Vue.extend({
     },
     // アイコン選択
     clickIcon(index: number) {
-      this.iconChecked = index
+      UserItemStore.changeMyIcon(index)
     },
 
     sendFavorite(topicId: string) {

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -28,7 +28,6 @@
       <div v-for="(chatData, index) in chatDataList" :key="index">
         <ChatRoom
           :topic-index="index"
-          :is-admin="isAdmin"
           :chat-data="chatData"
           :favorite-callback-register="favoriteCallbackRegister"
           :topic-state="topicStates[chatData.topic.id]"
@@ -68,7 +67,6 @@ type DataType = {
   room: Room
   isRoomStarted: boolean
   // ユーザー関連
-  isAdmin: boolean
   icons: any
 }
 Vue.use(VModal)
@@ -91,7 +89,6 @@ export default Vue.extend({
       room: {} as Room,
       isRoomStarted: false,
       // ユーザー関連
-      isAdmin: false,
       icons: [
         { url: require('@/assets/img/sushi_akami.png') },
         { url: require('@/assets/img/sushi_ebi.png') },
@@ -113,10 +110,13 @@ export default Vue.extend({
         topic,
       }))
     },
+    isAdmin(): boolean {
+      return UserItemStore.userItems.isAdmin
+    },
   },
   created(): any {
     if (this.$route.query.user === 'admin') {
-      this.isAdmin = true
+      UserItemStore.changeIsAdmin(true)
     }
   },
   mounted(): any {

--- a/app/front/store/userItems.ts
+++ b/app/front/store/userItems.ts
@@ -2,6 +2,7 @@ import { Module, VuexModule, Mutation } from 'vuex-module-decorators'
 
 type UserItem = {
   myIconId: number
+  isAdmin: boolean
 }
 
 @Module({
@@ -10,7 +11,7 @@ type UserItem = {
   namespaced: true,
 })
 export default class UserItems extends VuexModule {
-  private _userItems: UserItem = { myIconId: -1 }
+  private _userItems: UserItem = { myIconId: -1, isAdmin: false }
 
   public get userItems(): UserItem {
     return this._userItems
@@ -19,5 +20,10 @@ export default class UserItems extends VuexModule {
   @Mutation
   public changeMyIcon(index: number) {
     this._userItems.myIconId = index
+  }
+
+  @Mutation
+  public changeIsAdmin(state: boolean) {
+    this._userItems.isAdmin = state
   }
 }

--- a/app/front/store/userItems.ts
+++ b/app/front/store/userItems.ts
@@ -1,0 +1,23 @@
+import { Module, VuexModule, Mutation } from 'vuex-module-decorators'
+
+type UserItem = {
+  myIconId: number
+}
+
+@Module({
+  name: 'userItems',
+  stateFactory: true,
+  namespaced: true,
+})
+export default class UserItems extends VuexModule {
+  private _userItems: UserItem = { myIconId: -1 }
+
+  public get userItems(): UserItem {
+    return this._userItems
+  }
+
+  @Mutation
+  public changeMyIcon(index: number) {
+    this._userItems.myIconId = index
+  }
+}

--- a/app/front/utils/store-accessor.ts
+++ b/app/front/utils/store-accessor.ts
@@ -3,12 +3,15 @@ import { Store } from 'vuex'
 import { getModule } from 'vuex-module-decorators'
 import ChatItems from '~/store/chatItems'
 import Device from '~/store/device'
+import UserItems from '~/store/userItems'
 
 let ChatItemStore: ChatItems
 let DeviceStore: Device
+let UserItemStore: UserItems
 function initialiseStores(store: Store<any>): void {
   ChatItemStore = getModule(ChatItems, store)
   DeviceStore = getModule(Device, store)
+  UserItemStore = getModule(UserItems, store)
 }
 
-export { initialiseStores, ChatItemStore, DeviceStore }
+export { initialiseStores, ChatItemStore, DeviceStore, UserItemStore }


### PR DESCRIPTION
issue #206 

## やったこと
管理者かどうかを判定するisAdminと自分のアイコンIdの情報をVuexに移行した
isAdminとmyIconIdを合わせてUserItem型とし、それをVuexに移行させた
<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
