### PR TITLE
[fix]Safariの改行バグ

### DIFF
--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -350,6 +350,11 @@
     box-shadow: $gray 0px 2px 5px -1px, $gray 0px 1px 3px -1px;
     overflow: visible;
 
+    .text{
+      flex: 1;
+      word-break: break-all;
+    }
+
     &.reaction {
       box-shadow: none;
       margin-left: 2em;

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -9,7 +9,9 @@
         <img :src="icon" alt="" />
         <div class="admin-badge">運 営</div>
       </div>
-      <UrlToLink :text="message.content" />
+      <div class="text">
+        <UrlToLink :text="message.content" />
+      </div>
       <div class="comment-timestamp">
         {{ showTimestamp(message.timestamp) }}
       </div>
@@ -24,10 +26,10 @@
       <div class="icon-wrapper">
         <img :src="icon" alt="" />
       </div>
-      <div v-if="message.target == null">
+      <div v-if="message.target == null" class="text">
         <UrlToLink :text="message.content" />
       </div>
-      <div v-else>
+      <div v-else class="text">
         <span :style="{ color: 'gray', fontSize: '80%' }" @click.stop>
           <UrlToLink :text="`> ` + message.target.content" />
         </span>
@@ -52,7 +54,9 @@
         <div class="question-badge">Q</div>
         <div v-if="message.iconId == '0'" class="admin-badge">運 営</div>
       </div>
-      <UrlToLink :text="message.content" />
+      <div class="text">
+        <UrlToLink :text="message.content" />
+      </div>
       <div class="comment-timestamp">
         {{ showTimestamp(message.timestamp) }}
       </div>
@@ -72,7 +76,7 @@
         <div class="answer-badge">A</div>
         <div v-if="message.iconId == '0'" class="admin-badge">運 営</div>
       </div>
-      <div>
+      <div class="text">
         <span>
           <UrlToLink
             :text="'Q. ' + message.target.content"

--- a/app/front/components/UrlToLink.vue
+++ b/app/front/components/UrlToLink.vue
@@ -1,21 +1,15 @@
 <template>
-  <div>
+  <div class="text">
     <span v-for="(content, i) in text.split(/(https?:\/\/[^\s]*)/)" :key="i">
       <span v-if="i % 2 === 0">
         <span v-for="(token, j) in content.split(/(\n)/)" :key="j">
-          <span v-if="j % 2 == 0" style="word-break: break-all">
+          <span v-if="j % 2 == 0">
             {{ token }}
           </span>
           <br v-else />
         </span>
       </span>
-      <a
-        v-else
-        :href="content"
-        target="_blank"
-        style="word-break: break-all"
-        @click.stop
-      >
+      <a v-else :href="content" target="_blank" @click.stop>
         {{ content }}
       </a>
     </span>

--- a/app/front/components/UrlToLink.vue
+++ b/app/front/components/UrlToLink.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text">
+  <div>
     <span v-for="(content, i) in text.split(/(https?:\/\/[^\s]*)/)" :key="i">
       <span v-if="i % 2 === 0">
         <span v-for="(token, j) in content.split(/(\n)/)" :key="j">


### PR DESCRIPTION
issue #255 

## やったこと
コメントの本文について
`word-break: break-all`を設定しているものの本文の領域が文字の長さに依存する状態だったので、
```css
.text{
      flex: 1;
      word-break: break-all;
}
```
とすることで文字数関係なく幅いっぱいまで領域が確保されるようにした
その結果、admin、質問、回答では改行バグが消えた。

<!--
## やっていないこと
-->


## スクリーンショット
### before
<img width="686" alt="スクリーンショット 2021-07-01 19 15 54" src="https://user-images.githubusercontent.com/65712721/124108011-c3d3eb00-daa0-11eb-829b-27700d8ca442.png">

### after
<img width="686" alt="スクリーンショット 2021-07-01 19 17 19" src="https://user-images.githubusercontent.com/65712721/124108235-00074b80-daa1-11eb-895c-a006d3a30d6b.png">

<!--
## 動作確認手順
-->


## 困っていること
adminではない一般ユーザーの（質問/回答ではない）コメントがうまく領域が確保されない
Message.vueの
```vue:Message.vue
      <div v-if="message.target == null">
        <UrlToLink :text="message.content" />
      </div>
      <div v-else>
        <span :style="{ color: 'gray', fontSize: '80%' }" @click.stop>
          <UrlToLink :text="`> ` + message.target.content" />
        </span>
        <UrlToLink :text="message.content" />
      </div>
```
v-if、v-elseの部分を消すとうまくいくけど、なんでうまくいくのかやその直し方がよくわかっていない
<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
