### PR TITLE
Topic, TopicStateのvuex

### DIFF
--- a/app/front/components/AnalysisGraph.vue
+++ b/app/front/components/AnalysisGraph.vue
@@ -11,8 +11,8 @@
 </template>
 <script lang="ts">
 import Vue, { PropOptions } from "vue"
-import { Topic } from "@/models/contents"
 import { ChartData, ChartOptions } from "chart.js"
+import { Topic } from "@/models/contents"
 import ChartLine from "~/utils/ChartLine"
 import { ChatItemStore } from "~/store"
 

--- a/app/front/components/ChatRoom.vue
+++ b/app/front/components/ChatRoom.vue
@@ -68,7 +68,7 @@
     </div>
     <TextArea
       :topic="chatData.topic"
-      :disabled="isNotStartedTopic"
+      :disabled="topicState !== 'not-started'"
       @submit="clickSubmit"
     />
   </article>
@@ -78,13 +78,13 @@ import Vue, { PropOptions } from "vue"
 import throttle from "lodash.throttle"
 import { XIcon, ChevronUpIcon } from "vue-feather-icons"
 import AnalysisGraph from "./AnalysisGraph.vue"
-import { Topic, Message, TopicState, Question, Answer } from "@/models/contents"
+import { Topic, Message, Question, Answer } from "@/models/contents"
 import TopicHeader from "@/components/TopicHeader.vue"
 import MessageComponent from "@/components/Message.vue"
 import TextArea from "@/components/TextArea.vue"
 import FavoriteButton from "@/components/FavoriteButton.vue"
 import exportText from "@/utils/textExports"
-import { ChatItemStore } from "~/store"
+import { ChatItemStore, TopicStateItemStore } from "~/store"
 
 type ChatDataPropType = {
   topic: Topic
@@ -127,10 +127,6 @@ export default Vue.extend({
       type: Function,
       required: true,
     } as PropOptions<FavoriteCallbackRegisterPropType>,
-    topicState: {
-      type: String,
-      required: true,
-    } as PropOptions<TopicState>,
   },
   data(): DataType {
     return {
@@ -140,13 +136,13 @@ export default Vue.extend({
     }
   },
   computed: {
-    isNotStartedTopic() {
-      return this.topicState === "not-started"
-    },
     chatItems() {
       return ChatItemStore.chatItems.filter(
         ({ topicId }) => topicId === this.chatData.topic.id,
       )
+    },
+    topicState() {
+      return TopicStateItemStore.topicStateItems[this.chatData.topic.id]
     },
   },
   watch: {

--- a/app/front/components/ChatRoom.vue
+++ b/app/front/components/ChatRoom.vue
@@ -68,7 +68,7 @@
     </div>
     <TextArea
       :topic="chatData.topic"
-      :disabled="topicState !== 'not-started'"
+      :disabled="topicState == 'not-started'"
       @submit="clickSubmit"
     />
   </article>

--- a/app/front/components/SettingPage.vue
+++ b/app/front/components/SettingPage.vue
@@ -17,7 +17,7 @@
             <button
               class="material-icons copy-button"
               :disabled="
-                topics.findIndex((t) => topicStates[t.id] === 'active') == null
+                topics.findIndex((t) => topicStateItems[t.id] === 'active') == null
               "
               @click="writeToClipboard"
             >
@@ -41,31 +41,31 @@
           v-for="(topic, index) in topics"
           :key="topic.id"
           class="topic"
-          :class="topicStates[topic.id]"
+          :class="topicStateItems[topic.id]"
         >
           <div class="topic-number">{{ index }}</div>
           <div class="topic-name">
             {{ topic.title
-            }}<span v-if="topicStates[topic.id] === 'active'" class="label"
+            }}<span v-if="topicStateItems[topic.id] === 'active'" class="label"
               >進行中</span
             >
-            <span v-if="topicStates[topic.id] === 'paused'" class="label"
+            <span v-if="topicStateItems[topic.id] === 'paused'" class="label"
               >一時停止</span
             >
           </div>
           <div v-if="myIconId === 0" class="buttons">
             <button
-              v-if="topicStates[topic.id] != 'finished'"
+              v-if="topicStateItems[topic.id] != 'finished'"
               @click="clickPlayPauseButton(topic.id)"
             >
               <span class="material-icons">{{
-                playOrPause(topicStates[topic.id])
+                playOrPause(topicStateItems[topic.id])
               }}</span>
             </button>
             <button
               v-if="
-                topicStates[topic.id] === 'active' ||
-                topicStates[topic.id] === 'paused'
+                topicStateItems[topic.id] === 'active' ||
+                topicStateItems[topic.id] === 'paused'
               "
               @click="clickFinishButton(topic.id)"
             >
@@ -81,8 +81,8 @@
 <script lang="ts">
 import Vue, { PropOptions } from "vue"
 import ICONS from "@/utils/icons"
-import { TopicStatesPropType, Topic } from "@/models/contents"
-import { UserItemStore, TopicStore } from "~/store"
+import { Topic } from "@/models/contents"
+import { UserItemStore, TopicStore, TopicStateItemStore } from "~/store"
 
 export default Vue.extend({
   name: "SettingPage",
@@ -95,14 +95,13 @@ export default Vue.extend({
       type: String,
       required: true,
     },
-    topicStates: {
-      type: Object,
-      required: true,
-    } as PropOptions<TopicStatesPropType>,
   },
   computed: {
     topics(): Topic[]{
       return TopicStore.topics
+    },
+    topicStateItems() {
+      return TopicStateItemStore.topicStateItems
     },
     myIconId() {
       return UserItemStore.userItems.myIconId
@@ -130,11 +129,11 @@ export default Vue.extend({
       navigator.clipboard.writeText(this.shareUrl)
     },
     clickPlayPauseButton(topicId: string) {
-      if (this.topicStates[topicId] === "active") {
+      if (this.topicStateItems[topicId] === "active") {
         this.$emit("change-topic-state", topicId, "paused")
-      } else if (this.topicStates[topicId] === "paused") {
+      } else if (this.topicStateItems[topicId] === "paused") {
         this.$emit("change-topic-state", topicId, "active")
-      } else if (this.topicStates[topicId] === "not-started") {
+      } else if (this.topicStateItems[topicId] === "not-started") {
         this.$emit("change-topic-state", topicId, "active")
       }
     },
@@ -142,14 +141,14 @@ export default Vue.extend({
       if (
         confirm("本当にこのトピックを終了しますか？この操作は取り消せません")
       ) {
-        this.topicStates[topicId]! = "finished"
+        TopicStateItemStore.change({key: topicId, state: "finished"})
         this.$emit("change-topic-state", topicId, "closed")
       }
     },
     clickNextTopicButton() {
       // アクティブなトピックを探す
       const currentActiveTopicIndex = this.topics.findIndex(
-        (t) => this.topicStates[t.id] === "active",
+        (t) => this.topicStateItems[t.id] === "active",
       )
 
       if (currentActiveTopicIndex == null) {

--- a/app/front/components/SettingPage.vue
+++ b/app/front/components/SettingPage.vue
@@ -27,15 +27,6 @@
         </div>
       </div>
 
-      <button
-        v-if="myIconId === 0"
-        class="next-topic-button"
-        @click="clickNextTopicButton"
-      >
-        <span class="material-icons"> fast_forward </span>
-        次のトピックに遷移
-      </button>
-
       <div class="topic-list">
         <div
           v-for="(topic, index) in topics"
@@ -53,7 +44,7 @@
               >一時停止</span
             >
           </div>
-          <div v-if="myIconId === 0" class="buttons">
+          <div class="buttons">
             <button
               v-if="topicStateItems[topic.id] != 'finished'"
               @click="clickPlayPauseButton(topic.id)"
@@ -103,9 +94,6 @@ export default Vue.extend({
     topicStateItems() {
       return TopicStateItemStore.topicStateItems
     },
-    myIconId() {
-      return UserItemStore.userItems.myIconId
-    },
     icon() {
       return ICONS[UserItemStore.userItems.myIconId] ?? ICONS[0]
     },
@@ -143,22 +131,6 @@ export default Vue.extend({
       ) {
         TopicStateItemStore.change({key: topicId, state: "finished"})
         this.$emit("change-topic-state", topicId, "closed")
-      }
-    },
-    clickNextTopicButton() {
-      // アクティブなトピックを探す
-      const currentActiveTopicIndex = this.topics.findIndex(
-        (t) => this.topicStateItems[t.id] === "active",
-      )
-
-      if (currentActiveTopicIndex == null) {
-        return
-      }
-
-      const nextTopic = this.topics?.[currentActiveTopicIndex + 1]
-
-      if (nextTopic != null) {
-        this.$emit("change-topic-state", nextTopic.id, "active")
       }
     },
   },

--- a/app/front/components/SettingPage.vue
+++ b/app/front/components/SettingPage.vue
@@ -82,7 +82,7 @@
 import Vue, { PropOptions } from "vue"
 import ICONS from "@/utils/icons"
 import { TopicStatesPropType, Topic } from "@/models/contents"
-import { UserItemStore } from "~/store"
+import { UserItemStore, TopicStore } from "~/store"
 
 export default Vue.extend({
   name: "SettingPage",
@@ -95,16 +95,15 @@ export default Vue.extend({
       type: String,
       required: true,
     },
-    topics: {
-      type: Array,
-      required: true,
-    } as PropOptions<Topic[]>,
     topicStates: {
       type: Object,
       required: true,
     } as PropOptions<TopicStatesPropType>,
   },
   computed: {
+    topics(): Topic[]{
+      return TopicStore.topics
+    },
     myIconId() {
       return UserItemStore.userItems.myIconId
     },

--- a/app/front/components/SettingPage.vue
+++ b/app/front/components/SettingPage.vue
@@ -119,9 +119,7 @@ export default Vue.extend({
     clickPlayPauseButton(topicId: string) {
       if (this.topicStateItems[topicId] === "active") {
         this.$emit("change-topic-state", topicId, "paused")
-      } else if (this.topicStateItems[topicId] === "paused") {
-        this.$emit("change-topic-state", topicId, "active")
-      } else if (this.topicStateItems[topicId] === "not-started") {
+      } else if (this.topicStateItems[topicId] === ("paused" || "not-started")) {
         this.$emit("change-topic-state", topicId, "active")
       }
     },

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -22,7 +22,6 @@
         v-if="isDrawer && isAdmin"
         :room-id="room.id"
         :title="''"
-        :topics="topics"
         :topic-states="topicStates"
         @change-topic-state="changeTopicState"
       />
@@ -49,7 +48,7 @@ import ChatRoom from "@/components/ChatRoom.vue"
 import CreateRoomModal from "@/components/CreateRoomModal.vue"
 import SelectIconModal from "@/components/SelectIconModal.vue"
 import socket from "~/utils/socketIO"
-import { ChatItemStore, DeviceStore, UserItemStore } from "~/store"
+import { ChatItemStore, DeviceStore, UserItemStore, TopicStore } from "~/store"
 
 // 1つのトピックと、そのトピックに関するメッセージ一覧を含むデータ構造
 type ChatData = {
@@ -62,7 +61,6 @@ type DataType = {
   hamburgerMenu: string
   isDrawer: boolean
   // ルーム情報
-  topics: Topic[]
   activeUserCount: number
   topicStates: { [key: string]: TopicState }
   room: Room
@@ -82,7 +80,6 @@ export default Vue.extend({
       hamburgerMenu: "menu",
       isDrawer: false,
       // ルーム情報
-      topics: [],
       activeUserCount: 0,
       topicStates: {},
       room: {} as Room,
@@ -98,6 +95,9 @@ export default Vue.extend({
     isAdmin(): boolean {
       return UserItemStore.userItems.isAdmin
     },
+    topics(): Topic[] {
+      return TopicStore.topics
+    }
   },
   created(): any {
     if (this.$route.query.user === "admin") {
@@ -120,7 +120,7 @@ export default Vue.extend({
             this.topicStates[id] = state
           })
           ChatItemStore.addList(chatItems)
-          this.topics = topics
+          TopicStore.set(topics)
           this.activeUserCount = activeUserCount
           this.isRoomStarted = true // TODO: API側の対応が必要
         },
@@ -229,7 +229,7 @@ export default Vue.extend({
                 this.topicStates[id] = state
               })
               ChatItemStore.addList(chatItems)
-              this.topics = topics
+              TopicStore.set(topics)
               this.activeUserCount = activeUserCount
             },
           )
@@ -275,7 +275,7 @@ export default Vue.extend({
         },
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         (res: any) => {
-          this.topics = res.topics
+          TopicStore.set(res.topics)
           ChatItemStore.addList(res.chatItems)
           res.topics.forEach((topic: any) => {
             this.topicStates[topic.id] = topic.state
@@ -311,101 +311,4 @@ export default Vue.extend({
     },
   },
 })
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const TOPICS = [
-  {
-    id: "1",
-    title: "TITLE 0",
-    urls: {},
-  },
-  {
-    id: "2",
-    title: "TITLE 0",
-    urls: {},
-  },
-  {
-    id: "3",
-    title: "TITLE 0",
-    urls: {},
-  },
-]
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const CHAT_DUMMY_DATA: ChatItem[] = [
-  {
-    timestamp: 60,
-    iconId: "2",
-    createdAt: new Date("2021-05-08T00:00:00.000Z"),
-    id: "001",
-    topicId: "1",
-    type: "message",
-    content: "コメント",
-    target: null,
-  },
-  {
-    timestamp: 0,
-    iconId: "3",
-    createdAt: new Date("2021-05-08T00:00:00.000Z"),
-    target: {
-      id: "001",
-      topicId: "0",
-      type: "message",
-      iconId: "2",
-      timestamp: 0,
-      createdAt: new Date("2021-05-08T00:00:00.000Z"),
-      content: "コメント",
-      target: null,
-    },
-    id: "002",
-    topicId: "1",
-    type: "reaction",
-  },
-  {
-    timestamp: 0,
-    iconId: "2",
-    createdAt: new Date("2021-05-08T00:00:00.000Z"),
-    id: "003",
-    topicId: "1",
-    type: "question",
-    content: "質問",
-  },
-  {
-    timestamp: 0,
-    iconId: "3",
-    createdAt: new Date("2021-05-08T00:00:00.000Z"),
-    id: "004",
-    topicId: "1",
-    type: "answer",
-    content: "回答",
-    target: {
-      id: "003",
-      topicId: "0",
-      type: "question",
-      iconId: "2",
-      timestamp: 0,
-      createdAt: new Date("2021-05-08T00:00:00.000Z"),
-      content: "質問",
-    },
-  },
-  {
-    timestamp: 0,
-    iconId: "4",
-    createdAt: new Date("2021-05-08T00:00:00.000Z"),
-    target: {
-      id: "001",
-      topicId: "0",
-      type: "message",
-      iconId: "2",
-      timestamp: 0,
-      createdAt: new Date("2021-05-08T00:00:00.000Z"),
-      content: "コメント",
-      target: null,
-    },
-    id: "005",
-    topicId: "1",
-    type: "message",
-    content: "リプライ",
-  },
-]
 </script>

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -279,7 +279,7 @@ export default Vue.extend({
           TopicStore.set(res.topics)
           ChatItemStore.addList(res.chatItems)
           res.topics.forEach((topic: any) => {
-            TopicStateItemStore.change({key: res.topicId, state: topic.state})
+            TopicStateItemStore.change({key: topic.id, state: topic.state})
           })
         },
       )

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -29,7 +29,6 @@
           :topic-index="index"
           :chat-data="chatData"
           :favorite-callback-register="favoriteCallbackRegister"
-          :topic-state="topicStateItems[chatData.topic.id]"
           @send-stamp="sendFavorite"
           @topic-activate="changeActiveTopic"
         />

--- a/app/front/store/topicStateItems.ts
+++ b/app/front/store/topicStateItems.ts
@@ -1,4 +1,4 @@
-import { Module, VuexModule, Mutation } from "vuex-module-decorators"
+import { Module, VuexModule, Mutation, Action } from "vuex-module-decorators"
 import { TopicState } from "~/models/contents"
 
 type TopicStateItem = { [key: string]: TopicState }

--- a/app/front/store/topicStateItems.ts
+++ b/app/front/store/topicStateItems.ts
@@ -1,0 +1,27 @@
+import { Module, VuexModule, Mutation } from "vuex-module-decorators"
+import { TopicState } from "~/models/contents"
+
+type TopicStateItem = { [key: string]: TopicState }
+
+@Module({
+  name: "topicStateItems",
+  stateFactory: true,
+  namespaced: true,
+})
+export default class TopicStateItems extends VuexModule {
+  private _topicStateItems: TopicStateItem = {};
+
+  public get topicStateItems(): TopicStateItem {
+    return this._topicStateItems
+  }
+
+  @Mutation
+  public set(t: TopicStateItem) {
+    this._topicStateItems = t
+  }
+
+  @Mutation
+  public change({key, state}: {key: string, state: TopicState}) {
+    this._topicStateItems[key] = state
+  }
+}

--- a/app/front/store/topics.ts
+++ b/app/front/store/topics.ts
@@ -1,0 +1,20 @@
+import { Module, VuexModule, Mutation } from "vuex-module-decorators"
+import { Topic } from "~/models/contents"
+
+@Module({
+  name: "topics",
+  stateFactory: true,
+  namespaced: true,
+})
+export default class Topics extends VuexModule {
+  private _topics: Topic[] = []
+
+  public get topics(): Topic[] {
+    return this._topics
+  }
+
+  @Mutation
+  public set(t: Topic[]) {
+    this._topics = t
+  }
+}

--- a/app/front/utils/store-accessor.ts
+++ b/app/front/utils/store-accessor.ts
@@ -5,16 +5,19 @@ import ChatItems from "~/store/chatItems"
 import Device from "~/store/device"
 import UserItems from "~/store/userItems"
 import Topics from "~/store/topics"
+import TopicStateItems from "~/store/topicStateItems"
 
 let ChatItemStore: ChatItems
 let DeviceStore: Device
 let UserItemStore: UserItems
 let TopicStore: Topics
+let TopicStateItemStore: TopicStateItems
 function initialiseStores(store: Store<any>): void {
   ChatItemStore = getModule(ChatItems, store)
   DeviceStore = getModule(Device, store)
   UserItemStore = getModule(UserItems, store)
   TopicStore = getModule(Topics, store)
+  TopicStateItemStore = getModule(TopicStateItems, store)
 }
 
-export { initialiseStores, ChatItemStore, DeviceStore, UserItemStore, TopicStore }
+export { initialiseStores, ChatItemStore, DeviceStore, UserItemStore, TopicStore, TopicStateItemStore }

--- a/app/front/utils/store-accessor.ts
+++ b/app/front/utils/store-accessor.ts
@@ -4,14 +4,17 @@ import { getModule } from "vuex-module-decorators"
 import ChatItems from "~/store/chatItems"
 import Device from "~/store/device"
 import UserItems from "~/store/userItems"
+import Topics from "~/store/topics"
 
 let ChatItemStore: ChatItems
 let DeviceStore: Device
 let UserItemStore: UserItems
+let TopicStore: Topics
 function initialiseStores(store: Store<any>): void {
   ChatItemStore = getModule(ChatItems, store)
   DeviceStore = getModule(Device, store)
   UserItemStore = getModule(UserItems, store)
+  TopicStore = getModule(Topics, store)
 }
 
-export { initialiseStores, ChatItemStore, DeviceStore, UserItemStore }
+export { initialiseStores, ChatItemStore, DeviceStore, UserItemStore, TopicStore }


### PR DESCRIPTION
close #207

## やったこと
- topic
- topicState
のvuex
- 管理画面の便利ボタン削除
- 冗長な部分の削除
<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
連想配列作成と代入のみ
socket周りもまとめた方がいい気がしたが、room周りをvuex化するとスッキリするのだろうか