### PR TITLE
Tomokon/server/migrate room class delivery process to delivery layer

### DIFF
--- a/app/server/src/__test__/chat.ts
+++ b/app/server/src/__test__/chat.ts
@@ -4,11 +4,11 @@ import { io as Client, Socket as ClientSocket } from "socket.io-client"
 import { ArrayRange } from "../utils/range"
 import createSocketIOServer from "../ioServer"
 import { AdminBuildRoomParams } from "../events"
-import { Topic } from "../topic"
 import LocalMemoryUserRepository from "../infra/repository/User/LocalMemoryUserRepository"
 import EphemeralChatItemRepository from "../infra/repository/chatItem/EphemeralChatItemRepository"
 import EphemeralRoomRepository from "../infra/repository/room/EphemeralRoomRepository"
 import EphemeralStampRepository from "../infra/repository/stamp/EphemeralStampRepository"
+import Topic from "../domain/room/Topic"
 
 describe("機能テスト", () => {
   let io: Server
@@ -42,7 +42,7 @@ describe("機能テスト", () => {
   })
 
   let roomId: string
-  let topics: Topic[]
+  let topics: Omit<Topic, "state">[]
   const roomDataParams: AdminBuildRoomParams = {
     title: "TEST_ROOM_TITLE",
     topics: ArrayRange(10).map((i) => ({

--- a/app/server/src/__test__/chat.ts
+++ b/app/server/src/__test__/chat.ts
@@ -5,10 +5,11 @@ import { ArrayRange } from "../utils/range"
 import createSocketIOServer from "../ioServer"
 import { AdminBuildRoomParams } from "../events"
 import LocalMemoryUserRepository from "../infra/repository/User/LocalMemoryUserRepository"
-import EphemeralChatItemRepository from "../infra/repository/chatItem/EphemeralChatItemRepository"
-import EphemeralRoomRepository from "../infra/repository/room/EphemeralRoomRepository"
-import EphemeralStampRepository from "../infra/repository/stamp/EphemeralStampRepository"
 import Topic from "../domain/room/Topic"
+import { v4 as uuid } from "uuid"
+import RoomRepository from "../infra/repository/room/RoomRepository"
+import ChatItemRepository from "../infra/repository/chatItem/ChatItemRepository"
+import StampRepository from "../infra/repository/stamp/StampRepository"
 
 describe("機能テスト", () => {
   let io: Server
@@ -21,9 +22,9 @@ describe("機能テスト", () => {
     io = await createSocketIOServer(
       httpServer,
       LocalMemoryUserRepository.getInstance(),
-      new EphemeralRoomRepository(),
-      new EphemeralChatItemRepository(),
-      new EphemeralStampRepository(),
+      RoomRepository.getInstance(),
+      new ChatItemRepository(),
+      new StampRepository(),
     )
     httpServer.listen(async () => {
       const port = (httpServer as any).address().port
@@ -61,6 +62,11 @@ describe("機能テスト", () => {
     id: expect.any(String),
     state: "not-started",
   }))
+
+  const messageId = uuid()
+  const reactionId = uuid()
+  const questionId = uuid()
+  const answerId = uuid()
 
   describe("ルームを立てる", () => {
     test("管理者がルームを立てる", async (resolve) => {
@@ -239,7 +245,7 @@ describe("機能テスト", () => {
     test("Messageの投稿", (resolve) => {
       clientSockets[0].on("PUB_CHAT_ITEM", (res) => {
         expect(res).toStrictEqual({
-          id: "001",
+          id: messageId,
           topicId: topics[0].id,
           type: "message",
           iconId: "2",
@@ -253,7 +259,7 @@ describe("機能テスト", () => {
         resolve()
       })
       clientSockets[1].emit("POST_CHAT_ITEM", {
-        id: "001",
+        id: messageId,
         topicId: topics[0].id,
         type: "message",
         content: "コメント",
@@ -263,7 +269,7 @@ describe("機能テスト", () => {
     test("Reactionの投稿", (resolve) => {
       clientSockets[0].on("PUB_CHAT_ITEM", (res) => {
         expect(res).toStrictEqual({
-          id: "002",
+          id: reactionId,
           topicId: topics[0].id,
           type: "reaction",
           iconId: "3",
@@ -272,7 +278,7 @@ describe("機能テスト", () => {
             /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/,
           ),
           target: {
-            id: "001",
+            id: messageId,
             topicId: topics[0].id,
             type: "message",
             iconId: "2",
@@ -287,17 +293,17 @@ describe("機能テスト", () => {
         resolve()
       })
       clientSockets[2].emit("POST_CHAT_ITEM", {
-        id: "002",
+        id: reactionId,
         topicId: topics[0].id,
         type: "reaction",
-        reactionToId: "001",
+        reactionToId: messageId,
       })
     })
 
     test("Questionの投稿", (resolve) => {
       clientSockets[0].on("PUB_CHAT_ITEM", (res) => {
         expect(res).toStrictEqual({
-          id: "003",
+          id: questionId,
           topicId: topics[0].id,
           type: "question",
           iconId: "2",
@@ -310,7 +316,7 @@ describe("機能テスト", () => {
         resolve()
       })
       clientSockets[1].emit("POST_CHAT_ITEM", {
-        id: "003",
+        id: questionId,
         topicId: topics[0].id,
         type: "question",
         content: "質問",
@@ -320,7 +326,7 @@ describe("機能テスト", () => {
     test("Answerの投稿", (resolve) => {
       clientSockets[0].on("PUB_CHAT_ITEM", (res) => {
         expect(res).toStrictEqual({
-          id: "004",
+          id: answerId,
           topicId: topics[0].id,
           type: "answer",
           iconId: "3",
@@ -330,7 +336,7 @@ describe("機能テスト", () => {
           ),
           content: "回答",
           target: {
-            id: "003",
+            id: questionId,
             topicId: topics[0].id,
             type: "question",
             iconId: "2",
@@ -344,11 +350,11 @@ describe("機能テスト", () => {
         resolve()
       })
       clientSockets[2].emit("POST_CHAT_ITEM", {
-        id: "004",
+        id: answerId,
         topicId: topics[0].id,
         type: "answer",
         content: "回答",
-        target: "003",
+        target: questionId,
       })
     })
   })
@@ -472,7 +478,7 @@ describe("機能テスト", () => {
                 createdAt: expect.stringMatching(
                   /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/,
                 ),
-                id: "001",
+                id: messageId,
                 topicId: "1",
                 type: "message",
                 content: "コメント",
@@ -485,7 +491,7 @@ describe("機能テスト", () => {
                   /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/,
                 ),
                 target: {
-                  id: "001",
+                  id: messageId,
                   topicId: topics[0].id,
                   type: "message",
                   iconId: "2",
@@ -496,7 +502,7 @@ describe("機能テスト", () => {
                   content: "コメント",
                   target: null,
                 },
-                id: "002",
+                id: reactionId,
                 topicId: "1",
                 type: "reaction",
               },
@@ -506,7 +512,7 @@ describe("機能テスト", () => {
                 createdAt: expect.stringMatching(
                   /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/,
                 ),
-                id: "003",
+                id: questionId,
                 topicId: "1",
                 type: "question",
                 content: "質問",
@@ -517,12 +523,12 @@ describe("機能テスト", () => {
                 createdAt: expect.stringMatching(
                   /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/,
                 ),
-                id: "004",
+                id: answerId,
                 topicId: "1",
                 type: "answer",
                 content: "回答",
                 target: {
-                  id: "003",
+                  id: questionId,
                   topicId: topics[0].id,
                   type: "question",
                   iconId: "2",

--- a/app/server/src/domain/chatItem/Answer.ts
+++ b/app/server/src/domain/chatItem/Answer.ts
@@ -9,8 +9,8 @@ class Answer extends ChatItem {
     roomId: string,
     userIconId: string,
     createdAt: Date,
-    private readonly content: string,
-    private readonly target: Question,
+    public readonly content: string,
+    public readonly target: Question,
     timestamp?: number,
   ) {
     super(id, topicId, roomId, userIconId, createdAt, timestamp)

--- a/app/server/src/domain/chatItem/ChatItem.ts
+++ b/app/server/src/domain/chatItem/ChatItem.ts
@@ -3,11 +3,11 @@ import { ChatItemBase, ChatItemStore } from "../../chatItem"
 abstract class ChatItem {
   protected constructor(
     public readonly id: string,
-    private readonly topicId: string,
+    public readonly topicId: string,
     public readonly roomId: string,
-    private readonly userIconId: string,
-    private readonly createdAt: Date,
-    private readonly timestamp?: number,
+    public readonly userIconId: string,
+    public readonly createdAt: Date,
+    public readonly timestamp?: number,
   ) {}
 
   // TODO: モデルオブジェクトに変換のメソッドを持たせるのではなく、変換するためのクラスを使った方が責務の分離として正しい

--- a/app/server/src/domain/chatItem/IChatItemDelivery.ts
+++ b/app/server/src/domain/chatItem/IChatItemDelivery.ts
@@ -1,0 +1,13 @@
+import Message from "./Message"
+import Reaction from "./Reaction"
+import Question from "./Question"
+import Answer from "./Answer"
+
+interface IChatItemDelivery {
+  postMessage(message: Message): void
+  postReaction(reaction: Reaction): void
+  postQuestion(question: Question): void
+  postAnswer(answer: Answer): void
+}
+
+export default IChatItemDelivery

--- a/app/server/src/domain/chatItem/Message.ts
+++ b/app/server/src/domain/chatItem/Message.ts
@@ -9,8 +9,8 @@ class Message extends ChatItem {
     roomId: string,
     userIconId: string,
     createdAt: Date,
-    private readonly content: string,
-    private readonly target: Message | Answer | null,
+    public readonly content: string,
+    public readonly target: Message | Answer | null,
     timestamp?: number,
   ) {
     super(id, topicId, roomId, userIconId, createdAt, timestamp)

--- a/app/server/src/domain/chatItem/Question.ts
+++ b/app/server/src/domain/chatItem/Question.ts
@@ -8,7 +8,7 @@ class Question extends ChatItem {
     roomId: string,
     userIconId: string,
     createdAt: Date,
-    private readonly content: string,
+    public readonly content: string,
     timestamp?: number,
   ) {
     super(id, topicId, roomId, userIconId, createdAt, timestamp)

--- a/app/server/src/domain/chatItem/Reaction.ts
+++ b/app/server/src/domain/chatItem/Reaction.ts
@@ -11,7 +11,7 @@ class Reaction extends ChatItem {
     roomId: string,
     userIconId: string,
     createdAt: Date,
-    private readonly target: Message | Question | Answer,
+    public readonly target: Message | Question | Answer,
     timestamp?: number,
   ) {
     super(id, topicId, roomId, userIconId, createdAt, timestamp)

--- a/app/server/src/domain/room/IRoomDelivery.ts
+++ b/app/server/src/domain/room/IRoomDelivery.ts
@@ -1,0 +1,14 @@
+import { ChangeTopicStateType } from "../../events"
+
+interface IRoomDelivery {
+  start(roomId: string): void
+  finish(roomId: string): void
+  close(roomId: string): void
+  changeTopicState(
+    type: ChangeTopicStateType,
+    roomId: string,
+    topicId: string,
+  ): void
+}
+
+export default IRoomDelivery

--- a/app/server/src/domain/room/Room.ts
+++ b/app/server/src/domain/room/Room.ts
@@ -10,7 +10,7 @@ import {
 } from "../../chatItem"
 import { AdminChangeTopicStateParams } from "../../events"
 import { IServerSocket } from "../../serverSocket"
-import { v4 as getUUID } from "uuid"
+import { v4 as uuid } from "uuid"
 import ChatItemClass from "../chatItem/ChatItem"
 import StampClass from "../stamp/Stamp"
 import MessageClass from "../chatItem/Message"
@@ -329,7 +329,7 @@ class RoomClass {
   // Botメッセージ
   private postBotMessage = (topicId: string, content: string): MessageClass => {
     const botMessage = new MessageClass(
-      getUUID(),
+      uuid(),
       topicId,
       this.id,
       UserClass.ADMIN_ICON_ID,

--- a/app/server/src/domain/room/Room.ts
+++ b/app/server/src/domain/room/Room.ts
@@ -5,24 +5,23 @@ import {
   ChatItem,
   ChatItemStore,
   Message,
-  MessageStore,
   Question,
   QuestionStore,
   User,
 } from "../../chatItem"
 import { AdminChangeTopicStateParams, PostChatItemParams } from "../../events"
 import { IServerSocket } from "../../serverSocket"
-import { Topic, TopicState } from "../../topic"
 import { v4 as getUUID } from "uuid"
 import ChatItemClass from "../chatItem/ChatItem"
 import StampClass from "../stamp/Stamp"
+import Topic from "./Topic"
 
 class RoomClass {
   public static globalSocket: Server
 
   private users: (User & { socket: IServerSocket })[] = []
   private chatItems: ChatItemStore[] = []
-  public topics: (Topic & { state: TopicState })[]
+  public topics: Topic[]
   private stamps: StampClass[] = []
   private isOpened = false
 
@@ -45,7 +44,7 @@ class RoomClass {
   constructor(
     public readonly id: string,
     public readonly title: string,
-    topics: Omit<Topic, "id">[],
+    topics: Omit<Topic, "id" | "state">[],
   ) {
     this.topics = topics.map((topic, i) => ({
       ...topic,

--- a/app/server/src/domain/room/Room.ts
+++ b/app/server/src/domain/room/Room.ts
@@ -5,6 +5,7 @@ import {
   ChatItem,
   ChatItemStore,
   Message,
+  MessageStore,
   Question,
   QuestionStore,
   User,

--- a/app/server/src/domain/room/Topic.ts
+++ b/app/server/src/domain/room/Topic.ts
@@ -1,0 +1,12 @@
+type Topic = {
+  id: string
+  title: string
+  description: string
+  urls: Partial<Record<TopicLinkType, string>>
+  state: TopicState
+}
+
+type TopicLinkType = "github" | "slide" | "product"
+type TopicState = "not-started" | "active" | "paused" | "finished"
+
+export default Topic

--- a/app/server/src/domain/user/IUserDelivery.ts
+++ b/app/server/src/domain/user/IUserDelivery.ts
@@ -1,0 +1,8 @@
+import User from "./User"
+
+interface IUserDelivery {
+  enterRoom(user: User, activeUserCount: number): void
+  leaveRoom(user: User, activeUserCount: number): void
+}
+
+export default IUserDelivery

--- a/app/server/src/domain/user/User.ts
+++ b/app/server/src/domain/user/User.ts
@@ -1,30 +1,52 @@
 class User {
   public static readonly ADMIN_ICON_ID = "0"
 
-  private _roomId: string | undefined
-  private _iconId: string | undefined
+  private _roomId: string | null = null
+  private _iconId: string | null = null
 
   constructor(public readonly id: string) {}
 
-  public get roomId(): string {
-    if (this._roomId === undefined) {
-      throw new Error("Can't call roomId of User whose roomId is empty.")
-    }
-
+  public get roomId(): string | null {
     return this._roomId
   }
 
-  public get iconId(): string {
-    if (this._iconId === undefined) {
-      throw new Error("Can't call iconId of User whose iconId is empty.")
-    }
+  public getRoomIdOrThrow(): string {
+    this.assertIsInRoom()
+    return this._roomId as string
+  }
 
+  public get iconId(): string | null {
     return this._iconId
+  }
+
+  public getIconIdOrThrow(): string {
+    this.assertHasIconId()
+    return this._iconId as string
   }
 
   public enterRoom(roomId: string, iconId: string): void {
     this._roomId = roomId
     this._iconId = iconId
+  }
+
+  public leaveRoom(): void {
+    this.assertIsInRoom()
+    this.assertHasIconId()
+
+    this._roomId = null
+    this._iconId = null
+  }
+
+  private assertIsInRoom(): void {
+    if (this._roomId === null) {
+      throw new Error(`User(id:${this.id}) is not in any room.`)
+    }
+  }
+
+  private assertHasIconId(): void {
+    if (this._iconId === null) {
+      throw new Error(`User(id:${this.id}) doesn't have iconId.`)
+    }
   }
 }
 

--- a/app/server/src/events.ts
+++ b/app/server/src/events.ts
@@ -104,6 +104,8 @@ export type PostStampParams = { topicId: string }
  */
 export type PubStampParams = { iconId: string; topicId: string }
 
+export type ChangeTopicStateType = "CLOSE_AND_OPEN" | "PAUSE" | "OPEN" | "CLOSE"
+
 /**
  * トピックの状態を変更する
  * @user Admin
@@ -111,7 +113,7 @@ export type PubStampParams = { iconId: string; topicId: string }
  */
 export type AdminChangeTopicStateParams = {
   roomId: string // 変更対象のroomId
-  type: "CLOSE_AND_OPEN" | "PAUSE" | "OPEN" | "CLOSE"
+  type: ChangeTopicStateType
   topicId: string // 変更対象のtopicId
 }
 
@@ -179,10 +181,10 @@ export type PubLeaveRoomParams = {
 /**
  * トピックの状態を変更する
  * @user General
- * @type PUB_CHANGE_TOPIC_STATE
+ * @event PUB_CHANGE_TOPIC_STATE
  */
 export type PubChangeTopicStateParams = {
-  type: "CLOSE_AND_OPEN" | "PAUSE" | "OPEN" | "CLOSE" // 変更の種別
+  type: ChangeTopicStateType
   topicId: string // 変更対象のtopicId
 }
 

--- a/app/server/src/events.ts
+++ b/app/server/src/events.ts
@@ -1,6 +1,6 @@
 import { ChatItem } from "./chatItem"
 import { Room } from "./room"
-import { Topic, TopicLinkType, TopicState } from "./topic"
+import Topic from "./domain/room/Topic"
 
 /**
  * クライアントからサーバに送られるイベント名
@@ -38,11 +38,7 @@ export type EventName = ReceiveEventName | SendEventName
  */
 export type AdminBuildRoomParams = {
   title: string
-  topics: {
-    title: string
-    description: string
-    urls: Partial<Record<TopicLinkType, string>>
-  }[]
+  topics: Omit<Topic, "id" | "state">[]
 }
 
 /**
@@ -115,7 +111,7 @@ export type PubStampParams = { iconId: string; topicId: string }
  */
 export type AdminChangeTopicStateParams = {
   roomId: string // 変更対象のroomId
-  type: "CLOSE_AND_OPEN" | "PAUSE" | "OPEN" | "CLOSE" // 変更の種別
+  type: "CLOSE_AND_OPEN" | "PAUSE" | "OPEN" | "CLOSE"
   topicId: string // 変更対象のtopicId
 }
 
@@ -136,7 +132,7 @@ export type EnterRoomParams = {
  */
 export type EnterRoomResponse = {
   chatItems: ChatItem[]
-  topics: (Topic & { state: TopicState })[]
+  topics: Topic[]
   activeUserCount: number
 }
 
@@ -156,7 +152,7 @@ export type AdminEnterRoomParams = {
  */
 export type AdminEnterRoomResponse = {
   chatItems: ChatItem[]
-  topics: (Topic & { state: TopicState })[]
+  topics: Topic[]
   activeUserCount: number
 }
 

--- a/app/server/src/infra/delivery/chatItem/ChatItemDelivery.ts
+++ b/app/server/src/infra/delivery/chatItem/ChatItemDelivery.ts
@@ -1,0 +1,37 @@
+import IChatItemDelivery from "../../../domain/chatItem/IChatItemDelivery"
+import { Server } from "socket.io"
+import Message from "../../../domain/chatItem/Message"
+import ChatItemResponseBuilder from "../../../service/chatItem/ChatItemResponseBuilder"
+import Reaction from "../../../domain/chatItem/Reaction"
+import Question from "../../../domain/chatItem/Question"
+import Answer from "../../../domain/chatItem/Answer"
+
+class ChatItemDelivery implements IChatItemDelivery {
+  constructor(private readonly globalSocket: Server) {}
+
+  public postMessage(message: Message): void {
+    const messageResponse = ChatItemResponseBuilder.buildMessage(message)
+    this.globalSocket.to(message.roomId).emit("PUB_CHAT_ITEM", messageResponse)
+  }
+
+  public postReaction(reaction: Reaction): void {
+    const reactionResponse = ChatItemResponseBuilder.buildReaction(reaction)
+    this.globalSocket
+      .to(reaction.roomId)
+      .emit("PUB_CHAT_ITEM", reactionResponse)
+  }
+
+  public postQuestion(question: Question): void {
+    const questionResponse = ChatItemResponseBuilder.buildQuestion(question)
+    this.globalSocket
+      .to(question.roomId)
+      .emit("PUB_CHAT_ITEM", questionResponse)
+  }
+
+  public postAnswer(answer: Answer): void {
+    const answerResponse = ChatItemResponseBuilder.buildAnswer(answer)
+    this.globalSocket.to(answer.roomId).emit("PUB_CHAT_ITEM", answerResponse)
+  }
+}
+
+export default ChatItemDelivery

--- a/app/server/src/infra/delivery/room/RoomDelivery.ts
+++ b/app/server/src/infra/delivery/room/RoomDelivery.ts
@@ -1,0 +1,31 @@
+import IRoomDelivery from "../../../domain/room/IRoomDelivery"
+import { ChangeTopicStateType } from "../../../events"
+import { Server } from "socket.io"
+
+class RoomDelivery implements IRoomDelivery {
+  constructor(private readonly globalSocket: Server) {}
+
+  public start(roomId: string) {
+    this.globalSocket.to(roomId).emit("PUB_START_ROOM", {})
+  }
+
+  public finish(roomId: string) {
+    this.globalSocket.to(roomId).emit("PUB_FINISH_ROOM", {})
+  }
+
+  public close(roomId: string) {
+    this.globalSocket.to(roomId).emit("PUB_CLOSE_ROOM", {})
+  }
+
+  public changeTopicState(
+    type: ChangeTopicStateType,
+    roomId: string,
+    topicId: string,
+  ): void {
+    this.globalSocket
+      .to(roomId)
+      .emit("PUB_CHANGE_TOPIC_STATE", { type, topicId })
+  }
+}
+
+export default RoomDelivery

--- a/app/server/src/infra/delivery/stamp/StampDelivery.ts
+++ b/app/server/src/infra/delivery/stamp/StampDelivery.ts
@@ -23,11 +23,8 @@ class StampDelivery implements IStampDelivery {
   private constructor(private readonly globalSocket: Server) {}
 
   finishIntervalDelivery(): void {
-    if (this.intervalDeliveryTimer === null) {
-      throw new Error(
-        "Can't finish StampDelivery whose intervalDeliveryTimer is empty.",
-      )
-    }
+    if (this.intervalDeliveryTimer === null) return
+
     clearInterval(this.intervalDeliveryTimer)
     this.intervalDeliveryTimer = null
   }

--- a/app/server/src/infra/delivery/user/UserDelivery.ts
+++ b/app/server/src/infra/delivery/user/UserDelivery.ts
@@ -1,0 +1,28 @@
+import IUserDelivery from "../../../domain/user/IUserDelivery"
+import { Server, Socket } from "socket.io"
+import User from "../../../domain/user/User"
+
+class UserDelivery implements IUserDelivery {
+  constructor(
+    private readonly userSocket: Socket,
+    private readonly globalSocket: Server,
+  ) {}
+
+  public enterRoom(user: User, activeUserCount: number): void {
+    const roomId = user.getRoomIdOrThrow()
+    this.userSocket.broadcast.to(roomId).emit("PUB_ENTER_ROOM", {
+      iconId: user.iconId,
+      activeUserCount,
+    })
+  }
+
+  public leaveRoom(user: User, activeUserCount: number): void {
+    const roomId = user.getRoomIdOrThrow()
+    this.globalSocket.to(roomId).emit("PUB_LEAVE_ROOM", {
+      iconId: user.iconId,
+      activeUserCount,
+    })
+  }
+}
+
+export default UserDelivery

--- a/app/server/src/infra/repository/chatItem/ChatItemRepository.ts
+++ b/app/server/src/infra/repository/chatItem/ChatItemRepository.ts
@@ -122,6 +122,8 @@ class ChatItemRepository implements IChatItemRepository {
     const query = "SELECT * FROM chatitems WHERE id = $1"
     const res = (await this.pgClient.query(query, [chatItemId])).rows[0]
 
+    const topicId = `${res.topicid}`
+
     // NOTE: 複数回クエリを発行するとパフォーマンスの低下につながるので、一回のクエリでとってこれるならそうしたい
     let target = null
     switch (res.type) {
@@ -131,7 +133,7 @@ class ChatItemRepository implements IChatItemRepository {
         }
         return new Message(
           res.id,
-          res.topicid,
+          topicId,
           res.roomid,
           res.iconid,
           res.createdat,
@@ -143,7 +145,7 @@ class ChatItemRepository implements IChatItemRepository {
         target = (await this.find(res.targetid)) as Message | Question | Answer
         return new Reaction(
           res.id,
-          res.topicid,
+          topicId,
           res.roomid,
           res.iconid,
           res.createdat,
@@ -153,7 +155,7 @@ class ChatItemRepository implements IChatItemRepository {
       case "question":
         return new Question(
           res.id,
-          res.topicid,
+          topicId,
           res.roomid,
           res.iconid,
           res.createdat,
@@ -164,7 +166,7 @@ class ChatItemRepository implements IChatItemRepository {
         target = (await this.find(res.targetid)) as Question
         return new Answer(
           res.id,
-          res.topicid,
+          topicId,
           res.roomid,
           res.iconid,
           res.createdat,

--- a/app/server/src/ioServer.ts
+++ b/app/server/src/ioServer.ts
@@ -292,6 +292,16 @@ const createSocketIOServer = async (
 
       //接続解除時に行う処理
       socket.on("disconnect", () => {
+        try {
+          const userService = new UserService(userRepository, roomRepository)
+          userService.leaveRoom({ userId: socket.id })
+        } catch (e) {
+          console.log(
+            `${e.message ?? "Unknown error."} (LEAVE_ROOM)`,
+            new Date().toISOString(),
+          )
+        }
+
         activeUserCount--
       })
     },

--- a/app/server/src/room.ts
+++ b/app/server/src/room.ts
@@ -1,37 +1,7 @@
-import { ChatItem } from "./chatItem"
 import Topic from "./domain/room/Topic"
 
 export type Room = {
   id: string
   title: string
-  topics: Topic[]
-}
-
-export type BuildRoom = {
-  topics: Topic[]
-}
-
-export type BuildRoomReceive = {
-  topics: Topic[]
-}
-
-export type EnterRoom = {
-  iconId: number // 新しいユーザーのアイコンID
-  activeUserCount: number // 現在入室中のユーザー数（新しいユーザーを含む）
-}
-
-export type LeaveRoom = {
-  iconId: number // 退室したユーザーのアイコンID
-  activeUserCount: number // 現在入室中のユーザー数（ユーザーが退室した後の人数）
-}
-
-export type EnterRoomResponce = {
-  chatItems: ChatItem[] // 現在までのチャット履歴（stringはtopicIdが入る）
-  topics: Topic[] // トピック情報
-  activeUserCount: number // 現在入室中のユーザー数
-}
-
-export type EnterRoomReceive = {
-  iconId: string // アイコンID
-  roomId: string // 部屋のID [Option]
+  topics: Omit<Topic, "state">[]
 }

--- a/app/server/src/room.ts
+++ b/app/server/src/room.ts
@@ -1,5 +1,5 @@
 import { ChatItem } from "./chatItem"
-import { Topic } from "./topic"
+import Topic from "./domain/room/Topic"
 
 export type Room = {
   id: string

--- a/app/server/src/service/chatItem/ChatItemResponseBuilder.ts
+++ b/app/server/src/service/chatItem/ChatItemResponseBuilder.ts
@@ -1,0 +1,84 @@
+import {
+  Answer as AnswerResponse,
+  Message as MessageResponse,
+  Question as QuestionResponse,
+  Reaction as ReactionResponse,
+} from "../../chatItem"
+import Message from "../../domain/chatItem/Message"
+import Answer from "../../domain/chatItem/Answer"
+import Question from "../../domain/chatItem/Question"
+import Reaction from "../../domain/chatItem/Reaction"
+
+class ChatItemResponseBuilder {
+  public static buildMessage(message: Message): MessageResponse {
+    const t = message.target
+    let target = null
+    if (t instanceof Message) {
+      target = this.buildMessage(t)
+    } else if (t instanceof Answer) {
+      target = this.buildAnswer(t)
+    }
+
+    return {
+      id: message.id,
+      topicId: message.topicId,
+      type: "message",
+      iconId: message.userIconId,
+      createdAt: message.createdAt,
+      timestamp: message.timestamp,
+      target: target,
+      content: message.content,
+    }
+  }
+
+  public static buildReaction(reaction: Reaction): ReactionResponse {
+    const t = reaction.target
+    let target: MessageResponse | QuestionResponse | AnswerResponse
+    if (t instanceof Message) {
+      target = this.buildMessage(t)
+    } else if (t instanceof Question) {
+      target = this.buildQuestion(t)
+    } else {
+      target = this.buildAnswer(t)
+    }
+
+    return {
+      id: reaction.id,
+      topicId: reaction.topicId,
+      type: "reaction",
+      iconId: reaction.userIconId,
+      createdAt: reaction.createdAt,
+      timestamp: reaction.timestamp,
+      target,
+    }
+  }
+
+  public static buildQuestion(question: Question): QuestionResponse {
+    return {
+      id: question.id,
+      topicId: question.topicId,
+      type: "question",
+      iconId: question.userIconId,
+      createdAt: question.createdAt,
+      timestamp: question.timestamp,
+      content: question.content,
+    }
+  }
+
+  public static buildAnswer(answer: Answer): AnswerResponse {
+    const target = this.buildQuestion(answer.target)
+
+    return {
+      id: answer.id,
+      topicId: answer.topicId,
+      type: "answer",
+      iconId: answer.userIconId,
+      createdAt: answer.createdAt,
+      timestamp: answer.timestamp,
+      target,
+      content: answer.content,
+    }
+  }
+}
+
+export default ChatItemResponseBuilder

--- a/app/server/src/service/chatItem/ChatItemService.ts
+++ b/app/server/src/service/chatItem/ChatItemService.ts
@@ -13,12 +13,14 @@ import {
 } from "./commands"
 import IUserRepository from "../../domain/user/IUserRepository"
 import User from "../../domain/user/User"
+import IChatItemDelivery from "../../domain/chatItem/IChatItemDelivery"
 
 class ChatItemService {
   constructor(
     private readonly chatItemRepository: IChatItemRepository,
     private readonly roomRepository: IRoomRepository,
     private readonly userRepository: IUserRepository,
+    private readonly chatItemDelivery: IChatItemDelivery,
   ) {}
 
   public async postMessage(command: PostMessageCommand): Promise<void> {
@@ -48,6 +50,7 @@ class ChatItemService {
     room.postChatItem(command.userId, message)
     console.log(`message: ${command.content}(id: ${command.chatItemId})`)
 
+    this.chatItemDelivery.postMessage(message)
     this.chatItemRepository.saveMessage(message)
   }
 
@@ -72,9 +75,10 @@ class ChatItemService {
       room.getTimestamp(command.topicId),
     )
 
-    console.log(`reaction: to ${command.targetId}`)
     room.postChatItem(command.userId, reaction)
+    console.log(`reaction: to ${command.targetId}`)
 
+    this.chatItemDelivery.postReaction(reaction)
     this.chatItemRepository.saveReaction(reaction)
   }
 
@@ -98,6 +102,7 @@ class ChatItemService {
     room.postChatItem(command.userId, question)
     console.log(`question: ${command.content}(id: ${command.chatItemId})`)
 
+    this.chatItemDelivery.postQuestion(question)
     this.chatItemRepository.saveQuestion(question)
   }
 
@@ -125,6 +130,7 @@ class ChatItemService {
     room.postChatItem(command.userId, answer)
     console.log(`answer: ${command.content}(id: ${command.chatItemId})`)
 
+    this.chatItemDelivery.postAnswer(answer)
     this.chatItemRepository.saveAnswer(answer)
   }
 

--- a/app/server/src/service/chatItem/ChatItemService.ts
+++ b/app/server/src/service/chatItem/ChatItemService.ts
@@ -23,7 +23,10 @@ class ChatItemService {
 
   public async postMessage(command: PostMessageCommand): Promise<void> {
     const user = this.findUser(command.userId)
-    const room = this.findRoom(user.roomId)
+    const roomId = user.getRoomIdOrThrow()
+    const iconId = user.getIconIdOrThrow()
+
+    const room = this.findRoom(roomId)
     const target =
       command.targetId !== undefined && command.targetId !== null
         ? ((await this.chatItemRepository.find(command.targetId)) as
@@ -34,8 +37,8 @@ class ChatItemService {
     const message = new Message(
       command.chatItemId,
       command.topicId,
-      user.roomId,
-      user.iconId,
+      roomId,
+      iconId,
       new Date(),
       command.content,
       target,
@@ -50,7 +53,10 @@ class ChatItemService {
 
   public async postReaction(command: PostReactionCommand): Promise<void> {
     const user = this.findUser(command.userId)
-    const room = this.findRoom(user.roomId)
+    const roomId = user.getRoomIdOrThrow()
+    const iconId = user.getIconIdOrThrow()
+
+    const room = this.findRoom(roomId)
     const target = (await this.chatItemRepository.find(command.targetId)) as
       | Message
       | Question
@@ -59,8 +65,8 @@ class ChatItemService {
     const reaction = new Reaction(
       command.chatItemId,
       command.topicId,
-      user.roomId,
-      user.iconId,
+      roomId,
+      iconId,
       new Date(),
       target,
       room.getTimestamp(command.topicId),
@@ -74,13 +80,16 @@ class ChatItemService {
 
   public postQuestion(command: PostQuestionCommand): void {
     const user = this.findUser(command.userId)
-    const room = this.findRoom(user.roomId)
+    const roomId = user.getRoomIdOrThrow()
+    const iconId = user.getIconIdOrThrow()
+
+    const room = this.findRoom(roomId)
 
     const question = new Question(
       command.chatItemId,
       command.topicId,
-      user.roomId,
-      user.iconId,
+      roomId,
+      iconId,
       new Date(),
       command.content,
       room.getTimestamp(command.topicId),
@@ -94,7 +103,10 @@ class ChatItemService {
 
   public async postAnswer(command: PostAnswerCommand): Promise<void> {
     const user = this.findUser(command.userId)
-    const room = this.findRoom(user.roomId)
+    const roomId = user.getRoomIdOrThrow()
+    const iconId = user.getIconIdOrThrow()
+
+    const room = this.findRoom(roomId)
     const target = (await this.chatItemRepository.find(
       command.targetId,
     )) as Question
@@ -102,8 +114,8 @@ class ChatItemService {
     const answer = new Answer(
       command.chatItemId,
       command.topicId,
-      user.roomId,
-      user.iconId,
+      roomId,
+      iconId,
       new Date(),
       command.content,
       target,

--- a/app/server/src/service/room/RoomService.ts
+++ b/app/server/src/service/room/RoomService.ts
@@ -23,26 +23,31 @@ class RoomService {
 
   public start(userId: string): void {
     const user = this.findUser(userId)
+    const roomId = user.getRoomIdOrThrow()
 
-    const room = this.find(user.roomId)
+    const room = this.find(roomId)
     room.startRoom()
 
     this.roomRepository.update(room)
   }
 
+  // Roomを終了し、投稿をできなくする。閲覧は可能
   public finish(userId: string): void {
     const user = this.findUser(userId)
+    const roomId = user.getRoomIdOrThrow()
 
-    const room = this.find(user.roomId)
+    const room = this.find(roomId)
     room.finishRoom()
 
     this.roomRepository.update(room)
   }
 
+  // Roomをアーカイブし、閲覧できなくする。RESTのエンドポイントに移行予定
   public close(userId: string): void {
     const user = this.findUser(userId)
+    const roomId = user.getRoomIdOrThrow()
 
-    const room = this.find(user.roomId)
+    const room = this.find(roomId)
     room.closeRoom()
 
     this.roomRepository.update(room)
@@ -50,10 +55,11 @@ class RoomService {
 
   public changeTopicState(command: ChangeTopicStateCommand): void {
     const user = this.findUser(command.userId)
+    const roomId = user.getRoomIdOrThrow()
 
-    const room = this.find(user.roomId)
+    const room = this.find(roomId)
     room.changeTopicState({
-      roomId: user.roomId,
+      roomId: roomId,
       type: command.type,
       topicId: command.topicId,
     })

--- a/app/server/src/service/room/RoomService.ts
+++ b/app/server/src/service/room/RoomService.ts
@@ -66,14 +66,16 @@ class RoomService {
     const roomId = user.getRoomIdOrThrow()
 
     const room = this.find(roomId)
-    const { message, activeTopic } = room.changeTopicState({
+    const { messages, activeTopic } = room.changeTopicState({
       roomId: roomId,
       type: command.type,
       topicId: command.topicId,
     })
 
     this.roomDelivery.changeTopicState(command.type, roomId, command.topicId)
-    if (message !== null) this.chatItemDelivery.postMessage(message)
+    for (const m of messages) {
+      this.chatItemDelivery.postMessage(m)
+    }
     if (activeTopic !== null) {
       this.stampDelivery.startIntervalDelivery()
     } else {

--- a/app/server/src/service/room/commands.ts
+++ b/app/server/src/service/room/commands.ts
@@ -1,9 +1,9 @@
-import { Topic } from "../../topic"
+import Topic from "../../domain/room/Topic"
 
 export type BuildRoomCommand = {
   id: string
   title: string
-  topics: Omit<Topic, "id">[]
+  topics: Omit<Topic, "id" | "state">[]
 }
 
 export type ChangeTopicStateCommand = {

--- a/app/server/src/service/room/commands.ts
+++ b/app/server/src/service/room/commands.ts
@@ -1,3 +1,4 @@
+import { ChangeTopicStateType } from "../../events"
 import Topic from "../../domain/room/Topic"
 
 export type BuildRoomCommand = {
@@ -9,5 +10,5 @@ export type BuildRoomCommand = {
 export type ChangeTopicStateCommand = {
   userId: string
   topicId: string
-  type: "CLOSE_AND_OPEN" | "PAUSE" | "OPEN" | "CLOSE"
+  type: ChangeTopicStateType
 }

--- a/app/server/src/service/stamp/StampService.ts
+++ b/app/server/src/service/stamp/StampService.ts
@@ -17,15 +17,12 @@ class StampService {
 
   public post(command: PostStampCommand): void {
     const user = this.findUser(command.userId)
-    const room = this.findRoom(user.roomId)
+    const roomId = user.getRoomIdOrThrow()
+
+    const room = this.findRoom(roomId)
     const timestamp = room.getTimestamp(command.topicId)
 
-    const stamp = new Stamp(
-      command.userId,
-      user.roomId,
-      command.topicId,
-      timestamp,
-    )
+    const stamp = new Stamp(command.userId, roomId, command.topicId, timestamp)
     room.postStamp(stamp)
 
     this.stampDelivery.pushStamp(stamp)

--- a/app/server/src/service/user/UserService.ts
+++ b/app/server/src/service/user/UserService.ts
@@ -2,6 +2,7 @@ import {
   AdminEnterCommand,
   CreateUserCommand,
   UserEnterCommand,
+  UserLeaveCommand,
 } from "./commands"
 import IUserRepository from "../../domain/user/IUserRepository"
 import User from "../../domain/user/User"
@@ -44,6 +45,19 @@ class UserService {
     this.roomRepository.update(room)
 
     return room
+  }
+
+  public leaveRoom(command: UserLeaveCommand): void {
+    const user = this.userRepository.find(command.userId)
+    // まだRoomに参加していないユーザーなら何もしない
+    if (user.roomId === null) return
+
+    const room = this.findRoom(user.roomId)
+    user.leaveRoom()
+    const activeUserCount = room.leaveUser(user.id)
+
+    this.userRepository.update(user)
+    this.roomRepository.update(room)
   }
 
   private findRoom(roomId: string): RoomClass {

--- a/app/server/src/service/user/UserService.ts
+++ b/app/server/src/service/user/UserService.ts
@@ -9,11 +9,13 @@ import User from "../../domain/user/User"
 import IRoomRepository from "../../domain/room/IRoomRepository"
 import RoomClass from "../../domain/room/Room"
 import ServerSocket from "../../serverSocket"
+import IUserDelivery from "../../domain/user/IUserDelivery"
 
 class UserService {
   constructor(
     private readonly userRepository: IUserRepository,
     private readonly roomRepository: IRoomRepository,
+    private readonly userDelivery: IUserDelivery,
   ) {}
 
   public createUser(command: CreateUserCommand): void {
@@ -24,11 +26,13 @@ class UserService {
   public adminEnterRoom(command: AdminEnterCommand): RoomClass {
     const admin = this.userRepository.find(command.adminId)
     admin.enterRoom(command.roomId, User.ADMIN_ICON_ID)
-    this.userRepository.update(admin)
 
     const room = this.findRoom(command.roomId)
     const serverSocket = new ServerSocket(command.adminSocket, command.roomId)
-    room.joinUser(serverSocket, User.ADMIN_ICON_ID)
+    const activeUserCount = room.joinUser(serverSocket, User.ADMIN_ICON_ID)
+
+    this.userDelivery.enterRoom(admin, activeUserCount)
+    this.userRepository.update(admin)
     this.roomRepository.update(room)
 
     return room
@@ -37,11 +41,13 @@ class UserService {
   public enterRoom(command: UserEnterCommand): RoomClass {
     const user = this.userRepository.find(command.userId)
     user.enterRoom(command.roomId, command.iconId)
-    this.userRepository.update(user)
 
     const room = this.findRoom(command.roomId)
     const serverSocket = new ServerSocket(command.userSocket, command.roomId)
-    room.joinUser(serverSocket, command.iconId)
+    const activeUserCount = room.joinUser(serverSocket, command.iconId)
+
+    this.userDelivery.enterRoom(user, activeUserCount)
+    this.userRepository.update(user)
     this.roomRepository.update(room)
 
     return room
@@ -56,6 +62,7 @@ class UserService {
     user.leaveRoom()
     const activeUserCount = room.leaveUser(user.id)
 
+    this.userDelivery.leaveRoom(user, activeUserCount)
     this.userRepository.update(user)
     this.roomRepository.update(room)
   }

--- a/app/server/src/service/user/commands.ts
+++ b/app/server/src/service/user/commands.ts
@@ -16,3 +16,7 @@ export type UserEnterCommand = {
   iconId: string
   userSocket: Socket
 }
+
+export type UserLeaveCommand = {
+  userId: string
+}


### PR DESCRIPTION
## やったこと
- RoomClassで行われていたSocketIOを用いた配信処理を、Deliveryレイヤー(`infra/delivery/`)を作って移行した
- E2Eテスト(`__test__/chat.ts`)を、本番と同じくRDBを用いるようにした。
- type Topicを整理し、`domain/room/`配下に置いた
- `ChangeTopicState`の定義が散らばっていたのでまとめた
- 使われていなかった`/room.ts`内のtypeを削除した

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
テストしてみてください