### PR TITLE
ピン留めメッセージ追加に伴うAPI Spec修正

### DIFF
--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -576,6 +576,7 @@ definitions:
       timestamp:
         type: integer
         description: 'タイムスタンプ [ms]（active時以外に投稿されたものはnullになる）'
+        x-nullable: true
     required:
       - id
       - topicId

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -446,7 +446,8 @@ paths:
   /POST_PINNED_MESSAGE:
     put:
       summary: Your GET endpoint
-      tags: []
+      tags:
+        - SocketIO
       responses:
         '200':
           $ref: '#/responses/Success'
@@ -469,7 +470,8 @@ paths:
   /PUB_PINNED_MESSAGE:
     get:
       summary: Your GET endpoint
-      tags: []
+      tags:
+        - SocketIO
       responses:
         '200':
           $ref: '#/responses/Success'
@@ -577,6 +579,8 @@ definitions:
         type: integer
         description: 'タイムスタンプ [ms]（active時以外に投稿されたものはnullになる）'
         x-nullable: true
+      iconId:
+        type: integer
     required:
       - id
       - topicId

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -181,6 +181,10 @@ paths:
                 type: array
                 items:
                   $ref: '#/definitions/Stamp'
+              pinnedChatItemIds:
+                type: array
+                items:
+                  type: string
             required:
               - result
               - chatItems
@@ -256,6 +260,10 @@ paths:
               activeUserCount:
                 type: integer
                 description: アクティブユーザ数
+              pinnedChatItemIds:
+                type: array
+                items:
+                  type: string
         '400':
           $ref: '#/responses/Failure'
       description: |-
@@ -435,20 +443,7 @@ paths:
             type: array
             items:
               $ref: '#/definitions/Stamp'
-  /ADMIN_FINISH_ROOM:
-    put:
-      summary: ルームを終了
-      operationId: put-ADMIN_FINISH_ROOM
-      responses:
-        '200':
-          $ref: '#/responses/Success'
-        '400':
-          $ref: '#/responses/Failure'
-      description: '**管理者** ルームを終了する。これ以降はコメントやスタンプが投稿できなくなる。'
-      parameters: []
-      tags:
-        - SocketIO
-  /POST_PIN_MESSAGE:
+  /POST_PINNED_MESSAGE:
     put:
       summary: Your GET endpoint
       tags: []
@@ -471,7 +466,7 @@ paths:
                 type: string
           description: ''
     parameters: []
-  /PUB_PIN_MESSAGE:
+  /PUB_PINNED_MESSAGE:
     get:
       summary: Your GET endpoint
       tags: []
@@ -490,6 +485,20 @@ paths:
             properties:
               topicId:
                 type: number
+    parameters: []
+  /ADMIN_FINISH_ROOM:
+    put:
+      summary: ルームを終了
+      operationId: put-ADMIN_FINISH_ROOM
+      responses:
+        '200':
+          $ref: '#/responses/Success'
+        '400':
+          $ref: '#/responses/Failure'
+      description: '**管理者** ルームを終了する。これ以降はコメントやスタンプが投稿できなくなる。'
+      parameters: []
+      tags:
+        - SocketIO
 definitions:
   Topic:
     title: Topic

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: sushi-chat-api
-  version: '1.0'
+  version: 1.0.1
   description: |-
     sushi-chatのAPI定義です。
 
@@ -74,10 +74,6 @@ paths:
                   type: object
                   properties:
                     name:
-                      type: string
-                    description:
-                      type: string
-                    url:
                       type: string
                   required:
                     - name
@@ -257,10 +253,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/definitions/Stamp'
-              topics:
-                type: array
-                items:
-                  $ref: '#/definitions/Topic'
               activeUserCount:
                 type: integer
                 description: アクティブユーザ数
@@ -443,57 +435,6 @@ paths:
             type: array
             items:
               $ref: '#/definitions/Stamp'
-  /CHANGE_TOPIC_INFO:
-    post:
-      summary: ''
-      operationId: post-CHANGE_TOPIC_INFO
-      responses:
-        '200':
-          description: OK
-        '400':
-          $ref: '#/responses/Failure'
-      description: トピック情報（descriptionとURL）を変更する
-      parameters:
-        - in: body
-          name: body
-          schema:
-            type: object
-            properties:
-              topicId:
-                type: number
-                minimum: 0
-                exclusiveMinimum: true
-              description:
-                type: string
-                description: 'description, urlのどちらか一方または両方を指定'
-              url:
-                type: string
-                format: uri
-                description: 'description, urlのどちらか一方または両方を指定'
-            required:
-              - topicId
-          description: ''
-      tags:
-        - SocketIO
-  /PUB_TOPIC_INFO:
-    get:
-      summary: Your GET endpoint
-      tags:
-        - SocketIO
-      responses:
-        '200':
-          description: OK
-          schema:
-            type: object
-            properties:
-              result:
-                type: string
-                enum:
-                  - success
-              topic:
-                $ref: '#/definitions/Topic'
-      operationId: get-PUB_TOPIC_INFO
-      description: トピックの変更が通知される
   /ADMIN_FINISH_ROOM:
     put:
       summary: ルームを終了
@@ -507,6 +448,48 @@ paths:
       parameters: []
       tags:
         - SocketIO
+  /POST_PIN_MESSAGE:
+    put:
+      summary: Your GET endpoint
+      tags: []
+      responses:
+        '200':
+          $ref: '#/responses/Success'
+        '400':
+          $ref: '#/responses/Failure'
+      operationId: get-SPEAKER_PIN_MESSAGE
+      description: '**スピーカー** メッセージをピン留めする。既にピン留めメッセージがある場合は上書きする'
+      parameters:
+        - in: body
+          name: body
+          schema:
+            type: object
+            properties:
+              topicId:
+                type: number
+              chatItemId:
+                type: string
+          description: ''
+    parameters: []
+  /PUB_PIN_MESSAGE:
+    get:
+      summary: Your GET endpoint
+      tags: []
+      responses:
+        '200':
+          $ref: '#/responses/Success'
+        '400':
+          $ref: '#/responses/Failure'
+      operationId: get-PUB_PIN_MESSAGE
+      description: '**スピーカー** メッセージのピン留めを解除する。新しくピン留めする場合は`/POST_PIN_MESSAGE`を使い、単に解除したい場合のみこちらを利用する'
+      parameters:
+        - in: body
+          name: body
+          schema:
+            type: object
+            properties:
+              topicId:
+                type: number
 definitions:
   Topic:
     title: Topic
@@ -522,11 +505,6 @@ definitions:
         description: トピックの順序を表すindex（1始まり）
       name:
         type: string
-      description:
-        type: string
-      url:
-        type: string
-        format: uri
     required:
       - id
       - order
@@ -656,6 +634,7 @@ definitions:
       - not-started
       - ongoing
       - finished
+      - archived
 basePath: /api
 securityDefinitions:
   Bearer:

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -183,6 +183,7 @@ paths:
                   $ref: '#/definitions/Stamp'
               pinnedChatItemIds:
                 type: array
+                description: ピン留めされているChatItemのID
                 items:
                   type: string
             required:
@@ -262,6 +263,7 @@ paths:
                 description: アクティブユーザ数
               pinnedChatItemIds:
                 type: array
+                description: ピン留めされているChatItemのID
                 items:
                   type: string
         '400':


### PR DESCRIPTION
close #xxx

## やったこと
description / urlを廃止して、ピン留めに変更したため、関連するAPI定義を更新

### RoomState
- RoomStateに`archived`を追加

### topicのdescription / urlに関する部分を削除
- `POST /room`からurl, descriptionを削除
- Roomモデルからurl, descriptionを削除
- `/ENTER_ROOM`からurl, descriptionを削除
- `/PUB_TOPIC_INFO` /`CHANGE_TOPIC_INFO` を削除

### ピン留めに関する処理を追加
- `/POST_PINNED_MESSAGE`, `/PUB_PINNED_MESSAGE`を追加
- `/ENTER_ROOM`のレスポンスに`pinnedChatItemIds`を追加

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
