### PR TITLE
API定義を修正

### DIFF
--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -455,7 +455,7 @@ paths:
               $ref: '#/definitions/Stamp'
   /POST_PINNED_MESSAGE:
     put:
-      summary: Your GET endpoint
+      summary: ピン留めを編集
       tags:
         - SocketIO
       responses:
@@ -477,7 +477,7 @@ paths:
     parameters: []
   /PUB_PINNED_MESSAGE:
     get:
-      summary: Your GET endpoint
+      summary: ピン留めを配信
       tags:
         - SocketIO
       responses:

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -45,7 +45,7 @@ paths:
                 type: string
                 enum:
                   - success
-              rooms:
+              data:
                 type: array
                 items:
                   $ref: '#/definitions/Room'
@@ -122,11 +122,11 @@ paths:
                 type: string
                 enum:
                   - success
-              room:
+              data:
                 $ref: '#/definitions/Room'
             required:
               - result
-              - room
+              - data
         '400':
           $ref: '#/responses/Failure'
       operationId: get-room-id
@@ -173,19 +173,22 @@ paths:
                 type: string
                 enum:
                   - success
-              chatItems:
-                type: array
-                items:
-                  $ref: '#/definitions/ChatItem'
-              stamps:
-                type: array
-                items:
-                  $ref: '#/definitions/Stamp'
-              pinnedChatItemIds:
-                type: array
-                description: ピン留めされているChatItemのID
-                items:
-                  type: string
+              data:
+                type: object
+                properties:
+                  chatItems:
+                    type: array
+                    items:
+                      $ref: '#/definitions/ChatItem'
+                  stamps:
+                    type: array
+                    items:
+                      $ref: '#/definitions/Stamp'
+                  pinnedChatItemIds:
+                    type: array
+                    description: ピン留めされているChatItemのID
+                    items:
+                      type: string
             required:
               - result
               - chatItems

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -250,22 +250,29 @@ paths:
           schema:
             type: object
             properties:
-              chatItems:
-                type: array
-                items:
-                  $ref: '#/definitions/ChatItem'
-              stamps:
-                type: array
-                items:
-                  $ref: '#/definitions/Stamp'
-              activeUserCount:
-                type: integer
-                description: アクティブユーザ数
-              pinnedChatItemIds:
-                type: array
-                description: ピン留めされているChatItemのID
-                items:
-                  type: string
+              result:
+                type: string
+                enum:
+                  - success
+              date:
+                type: object
+                properties:
+                  chatItems:
+                    type: array
+                    items:
+                      $ref: '#/definitions/ChatItem'
+                  stamps:
+                    type: array
+                    items:
+                      $ref: '#/definitions/Stamp'
+                  activeUserCount:
+                    type: integer
+                    description: アクティブユーザ数
+                  pinnedChatItemIds:
+                    type: array
+                    description: ピン留めされているChatItemのID
+                    items:
+                      type: string
         '400':
           $ref: '#/responses/Failure'
       description: |-

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -402,9 +402,7 @@ paths:
         '200':
           description: OK
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/ChatItem'
+            $ref: '#/definitions/ChatItem'
       operationId: get-PUB_CHAT_ITEM
       description: '**管理者・一般ユーザ** チャットアイテムが配信される'
   /POST_STAMP:

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -548,15 +548,11 @@ definitions:
       adminInviteKey:
         type: string
         description: 管理者招待キー（管理者がAPIを叩いた場合のみ含まれる）
-      isArchived:
-        type: string
-        description: ルームがアーカイブされているか（管理者がAPIを叩いた場合のみ含まれる）
     required:
       - id
       - name
       - topics
       - state
-    x-examples: {}
   ChatItem:
     title: ChatItem
     type: object

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -65,7 +65,7 @@ paths:
           schema:
             type: object
             properties:
-              title:
+              name:
                 type: string
                 description: ルーム名
               topics:
@@ -73,14 +73,14 @@ paths:
                 items:
                   type: object
                   properties:
-                    title:
+                    name:
                       type: string
                   required:
-                    - title
+                    - name
               description:
                 type: string
             required:
-              - title
+              - name
               - topics
       responses:
         '200':
@@ -268,14 +268,14 @@ paths:
                     type: array
                     items:
                       $ref: '#/definitions/Stamp'
+                  activeUserCount:
+                    type: integer
+                    description: アクティブユーザ数
                   pinnedChatItemIds:
                     type: array
                     description: ピン留めされているChatItemのID
                     items:
                       type: string
-                  activeUserCount:
-                    type: integer
-                    description: アクティブユーザ数
         '400':
           $ref: '#/responses/Failure'
       description: |-
@@ -471,6 +471,8 @@ paths:
             properties:
               chatItemId:
                 type: string
+                description: ピン留めを外す場合はnullを指定する
+                x-nullable: true
           description: ''
     parameters: []
   /PUB_PINNED_MESSAGE:
@@ -484,12 +486,16 @@ paths:
           schema:
             type: object
             properties:
+              topicId:
+                type: number
               chatItemId:
                 type: string
+                description: nullの場合はピン留め解除
+                x-nullable: true
         '400':
           $ref: '#/responses/Failure'
       operationId: get-PUB_PIN_MESSAGE
-      description: '**スピーカー** メッセージのピン留めを解除する。新しくピン留めする場合は`/POST_PIN_MESSAGE`を使い、単に解除したい場合のみこちらを利用する'
+      description: ピン留めを配信する。chatItemIdがnullの場合は、ピン留め解除の配信になる。
       parameters: []
     parameters: []
   /ADMIN_FINISH_ROOM:
@@ -518,21 +524,20 @@ definitions:
         type: integer
         minimum: 1
         description: トピックの順序を表すindex（1始まり）
-      title:
+      name:
         type: string
     required:
       - id
       - order
-      - title
+      - name
   Room:
     title: Room
     type: object
-    x-examples: {}
     properties:
       id:
         type: string
         format: uuid
-      title:
+      name:
         type: string
       topics:
         type: array
@@ -551,7 +556,7 @@ definitions:
         description: 管理者招待キー（管理者がAPIを叩いた場合のみ含まれる）
     required:
       - id
-      - title
+      - name
       - topics
       - state
   ChatItem:

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -453,8 +453,6 @@ paths:
       responses:
         '200':
           $ref: '#/responses/Success'
-        '400':
-          $ref: '#/responses/Failure'
       operationId: get-SPEAKER_PIN_MESSAGE
       description: '**スピーカー** メッセージをピン留めする。既にピン留めメッセージがある場合は上書きする'
       parameters:
@@ -463,8 +461,6 @@ paths:
           schema:
             type: object
             properties:
-              topicId:
-                type: number
               chatItemId:
                 type: string
           description: ''
@@ -476,19 +472,17 @@ paths:
         - SocketIO
       responses:
         '200':
-          $ref: '#/responses/Success'
+          description: OK
+          schema:
+            type: object
+            properties:
+              chatItemId:
+                type: string
         '400':
           $ref: '#/responses/Failure'
       operationId: get-PUB_PIN_MESSAGE
       description: '**スピーカー** メッセージのピン留めを解除する。新しくピン留めする場合は`/POST_PIN_MESSAGE`を使い、単に解除したい場合のみこちらを利用する'
-      parameters:
-        - in: body
-          name: body
-          schema:
-            type: object
-            properties:
-              topicId:
-                type: number
+      parameters: []
     parameters: []
   /ADMIN_FINISH_ROOM:
     put:

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -65,7 +65,7 @@ paths:
           schema:
             type: object
             properties:
-              name:
+              title:
                 type: string
                 description: ルーム名
               topics:
@@ -73,14 +73,14 @@ paths:
                 items:
                   type: object
                   properties:
-                    name:
+                    title:
                       type: string
                   required:
-                    - name
+                    - title
               description:
                 type: string
             required:
-              - name
+              - title
               - topics
       responses:
         '200':
@@ -268,14 +268,14 @@ paths:
                     type: array
                     items:
                       $ref: '#/definitions/Stamp'
-                  activeUserCount:
-                    type: integer
-                    description: アクティブユーザ数
                   pinnedChatItemIds:
                     type: array
                     description: ピン留めされているChatItemのID
                     items:
                       type: string
+                  activeUserCount:
+                    type: integer
+                    description: アクティブユーザ数
         '400':
           $ref: '#/responses/Failure'
       description: |-
@@ -518,20 +518,21 @@ definitions:
         type: integer
         minimum: 1
         description: トピックの順序を表すindex（1始まり）
-      name:
+      title:
         type: string
     required:
       - id
       - order
-      - name
+      - title
   Room:
     title: Room
     type: object
+    x-examples: {}
     properties:
       id:
         type: string
         format: uuid
-      name:
+      title:
         type: string
       topics:
         type: array
@@ -550,7 +551,7 @@ definitions:
         description: 管理者招待キー（管理者がAPIを叩いた場合のみ含まれる）
     required:
       - id
-      - name
+      - title
       - topics
       - state
   ChatItem:

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -92,11 +92,11 @@ paths:
                 type: string
                 enum:
                   - success
-              room:
+              data:
                 $ref: '#/definitions/Room'
             required:
               - result
-              - room
+              - data
         '400':
           $ref: '#/responses/Failure'
         '401':


### PR DESCRIPTION
close #xxx

## やったこと
- `ENTER_ROOM` `/room/{id}/history` の正常系のレスポンス形式を統一した
  - `{ result: 'success', data: any }`  という形式に統一した
- ピン留めメッセージのAPI定義をミスっていたのを修正
- PUB_CHAT_ITEMのレスポンスをミスっていたのを修正
- `GET /room`に`isArchived`フラグが残っていたので除去
- RoomとTopicのnameをtitleにリネーム

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
