### PR TITLE
管理者招待

### DIFF
--- a/app/server/src/domain/room/Room.ts
+++ b/app/server/src/domain/room/Room.ts
@@ -57,9 +57,11 @@ class RoomClass {
       Partial<Pick<Topic, "id" | "state">>)[],
     topicTimeData: Record<string, TopicTimeData> = {},
     private userIds = new Set<string>([]),
+    private adminIds = new Set<string>([]),
     private _chatItems: ChatItem[] = [],
     private stampsCount = 0,
     private _state: RoomState = "not-started",
+    private adminInviteKey = "",
   ) {
     this._topics = topics.map((topic, i) => ({
       ...topic,
@@ -118,6 +120,18 @@ class RoomClass {
     this.assertUserExists(userId)
     this.userIds.delete(userId)
     return this.activeUserCount
+  }
+
+  /**
+   * 管理者をルームに招待する
+   * @param userId 管理者にするadminのID
+   * @param adminInviteKey 送られてきた招待キー
+   * @returns number アクティブなユーザー数
+   */
+  public inviteAdmin = (userId: string, adminInviteKey: string): boolean => {
+    this.assertSameAdminInviteKey(adminInviteKey)
+    this.adminIds.add(userId)
+    return true
   }
 
   /**
@@ -339,6 +353,15 @@ class RoomClass {
     if (!exists) {
       throw new Error(
         `[sushi-chat-server] User(id: ${userId}) does not exists.`,
+      )
+    }
+  }
+
+  private assertSameAdminInviteKey(adminInviteKey: string) {
+    const same = this.adminInviteKey === adminInviteKey
+    if (!same) {
+      throw new Error(
+        `[sushi-chat-server] adminInviteKey(${adminInviteKey}) does not matches.`,
       )
     }
   }

--- a/app/server/src/domain/room/Room.ts
+++ b/app/server/src/domain/room/Room.ts
@@ -130,7 +130,6 @@ class RoomClass {
   public inviteAdmin = (adminId: string, adminInviteKey: string): void => {
     this.assertSameAdminInviteKey(adminInviteKey)
     this.adminIds.add(adminId)
-    return
   }
 
   /**

--- a/app/server/src/domain/room/Room.ts
+++ b/app/server/src/domain/room/Room.ts
@@ -124,13 +124,13 @@ class RoomClass {
 
   /**
    * 管理者をルームに招待する
-   * @param userId 管理者にするadminのID
+   * @param adminId 管理者にするadminのID
    * @param adminInviteKey 送られてきた招待キー
    * @returns number アクティブなユーザー数
    */
-  public inviteAdmin = (userId: string, adminInviteKey: string): boolean => {
+  public inviteAdmin = (adminId: string, adminInviteKey: string): boolean => {
     this.assertSameAdminInviteKey(adminInviteKey)
-    this.adminIds.add(userId)
+    this.adminIds.add(adminId)
     return true
   }
 

--- a/app/server/src/domain/room/Room.ts
+++ b/app/server/src/domain/room/Room.ts
@@ -126,12 +126,11 @@ class RoomClass {
    * 管理者をルームに招待する
    * @param adminId 管理者にするadminのID
    * @param adminInviteKey 送られてきた招待キー
-   * @returns number アクティブなユーザー数
    */
-  public inviteAdmin = (adminId: string, adminInviteKey: string): boolean => {
+  public inviteAdmin = (adminId: string, adminInviteKey: string): void => {
     this.assertSameAdminInviteKey(adminInviteKey)
     this.adminIds.add(adminId)
-    return true
+    return
   }
 
   /**

--- a/app/server/src/domain/room/Room.ts
+++ b/app/server/src/domain/room/Room.ts
@@ -53,6 +53,7 @@ class RoomClass {
     public readonly id: string,
     public readonly title: string,
     public readonly description: string,
+    public readonly adminInviteKey: string,
     topics: (Omit<Topic, "id" | "state"> &
       Partial<Pick<Topic, "id" | "state">>)[],
     topicTimeData: Record<string, TopicTimeData> = {},
@@ -61,7 +62,6 @@ class RoomClass {
     private _chatItems: ChatItem[] = [],
     private stampsCount = 0,
     private _state: RoomState = "not-started",
-    private adminInviteKey = "",
   ) {
     this._topics = topics.map((topic, i) => ({
       ...topic,

--- a/app/server/src/infra/repository/room/RoomRepository.ts
+++ b/app/server/src/infra/repository/room/RoomRepository.ts
@@ -111,6 +111,7 @@ class RoomRepository implements IRoomRepository {
       topics,
       topicTimeData,
       userIds,
+      new Set<string>([]) /* これはadminIdsです。 */,
       chatItems,
       stampsCount,
       roomState,

--- a/app/server/src/infra/repository/room/RoomRepository.ts
+++ b/app/server/src/infra/repository/room/RoomRepository.ts
@@ -108,6 +108,7 @@ class RoomRepository implements IRoomRepository {
       roomId,
       roomTitle,
       "" /* これはdescriptionです。 */,
+      "" /* これはadminInviteKeyです。 */,
       topics,
       topicTimeData,
       userIds,

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -38,7 +38,7 @@ export const restSetup = (
         ],
       })
     } catch (e) {
-      res.send({
+      res.status(400).send({
         result: "error",
         error: {
           code: 400,
@@ -52,7 +52,7 @@ export const restSetup = (
   app.post("/room/:id/invite", (req, res) => {
     const adminInviteKey = req.query["admin_invite_key"]
     if (!adminInviteKey) {
-      res.send({
+      res.status(400).send({
         result: "error",
         error: {
           code: 400,
@@ -62,7 +62,7 @@ export const restSetup = (
       return
     }
     if (typeof adminInviteKey !== "string") {
-      res.send({
+      res.status(400).send({
         result: "error",
         error: {
           code: 400,
@@ -79,7 +79,7 @@ export const restSetup = (
       })
       .then(() => res.send({ result: "success" }))
       .catch((e) => {
-        res.send({
+        res.status(400).send({
           result: "error",
           error: {
             code: 400,

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -48,7 +48,7 @@ export const restSetup = (
   })
 
   // ルームと新しい管理者を紐付ける
-  app.post("/user/:id/invite", (req, res) => {
+  app.post("/room/:id/invite", (req, res) => {
     try {
       roomService.inviteAdmin({
         id: req.params.id,

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -29,6 +29,7 @@ export const restSetup = (
             description: newRoom.description,
             topics: newRoom.topics,
             state: newRoom.state,
+            adminInviteKey: newRoom.adminInviteKey,
             /*
               startDate: newRoom.startDate,
               adminInviteKey: newRoom.adminInviteKey

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -50,6 +50,11 @@ export const restSetup = (
   // ルームと新しい管理者を紐付ける
   app.post("/user/:id/invite", (req, res) => {
     try {
+      roomService.invite({
+        id: req.params.id,
+        adminInviteKey: req.body.adminInviteKey,
+      })
+
       res.send({ result: "success" })
     } catch (e) {
       res.send({

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -46,4 +46,19 @@ export const restSetup = (
       })
     }
   })
+
+  // ルームと新しい管理者を紐付ける
+  app.post("/user/:id/invite", (req, res) => {
+    try {
+      res.send({ result: "success" })
+    } catch (e) {
+      res.send({
+        result: "error",
+        error: {
+          code: 400,
+          message: `${e.message ?? "Unknown error."} (ADMIN_BUILD_ROOM)`,
+        },
+      })
+    }
+  })
 }

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -66,7 +66,7 @@ export const restSetup = (
         result: "error",
         error: {
           code: 400,
-          message: `admin_invite_key has invailed syntax. (ADMIN_INVITE_ROOM)`,
+          message: `invaild parameter. (ADMIN_INVITE_ROOM)`,
         },
       })
       return

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -49,21 +49,21 @@ export const restSetup = (
 
   // ルームと新しい管理者を紐付ける
   app.post("/room/:id/invite", (req, res) => {
-    try {
-      roomService.inviteAdmin({
+    roomService
+      .inviteAdmin({
         id: req.params.id,
         adminInviteKey: req.body.adminInviteKey,
+        adminId: "should get from header",
       })
-
-      res.send({ result: "success" })
-    } catch (e) {
-      res.send({
-        result: "error",
-        error: {
-          code: 400,
-          message: `${e.message ?? "Unknown error."} (ADMIN_BUILD_ROOM)`,
-        },
+      .then(() => res.send({ result: "success" }))
+      .catch((e) => {
+        res.send({
+          result: "error",
+          error: {
+            code: 400,
+            message: `${e.message ?? "Unknown error."} (ADMIN_INVITE_ROOM)`,
+          },
+        })
       })
-    }
   })
 }

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -50,10 +50,31 @@ export const restSetup = (
 
   // ルームと新しい管理者を紐付ける
   app.post("/room/:id/invite", (req, res) => {
+    const adminInviteKey = req.query["admin_invite_key"]
+    if (!adminInviteKey) {
+      res.send({
+        result: "error",
+        error: {
+          code: 400,
+          message: `invite admin needs admin_invite_key. (ADMIN_INVITE_ROOM)`,
+        },
+      })
+      return
+    }
+    if (typeof adminInviteKey !== "string") {
+      res.send({
+        result: "error",
+        error: {
+          code: 400,
+          message: `admin_invite_key has invailed syntax. (ADMIN_INVITE_ROOM)`,
+        },
+      })
+      return
+    }
     roomService
       .inviteAdmin({
         id: req.params.id,
-        adminInviteKey: req.body.adminInviteKey,
+        adminInviteKey: adminInviteKey,
         adminId: "should get from header",
       })
       .then(() => res.send({ result: "success" }))

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -50,7 +50,7 @@ export const restSetup = (
   // ルームと新しい管理者を紐付ける
   app.post("/user/:id/invite", (req, res) => {
     try {
-      roomService.invite({
+      roomService.inviteAdmin({
         id: req.params.id,
         adminInviteKey: req.body.adminInviteKey,
       })

--- a/app/server/src/service/room/RestRoomService.ts
+++ b/app/server/src/service/room/RestRoomService.ts
@@ -29,7 +29,7 @@ class RestRoomService {
   public async inviteAdmin(command: InviteRoomCommand): Promise<RoomClass> {
     const room = await this.find(command.id)
     // きっとこんな感じになると思っている
-    room.inviteAdmin(command.userId, command.adminInviteKey)
+    room.inviteAdmin(command.adminId, command.adminInviteKey)
 
     this.roomRepository.update(room)
     console.log(`new admin invited to room: ${command.id}`)

--- a/app/server/src/service/room/RestRoomService.ts
+++ b/app/server/src/service/room/RestRoomService.ts
@@ -3,7 +3,7 @@ import RoomClass from "../../domain/room/Room"
 import { BuildRoomCommand, InviteRoomCommand } from "./commands"
 import IUserRepository from "../../domain/user/IUserRepository"
 import User from "../../domain/user/User"
-
+import { v4 as uuid } from "uuid"
 class RestRoomService {
   constructor(
     private readonly roomRepository: IRoomRepository,
@@ -12,10 +12,14 @@ class RestRoomService {
 
   // Roomを作成する。
   public build(command: BuildRoomCommand): RoomClass {
+    // TODO: いつか適切な場所に移動する
+    const adminInviteKey = uuid()
+
     const room = new RoomClass(
       command.id,
       command.title,
       command.description ?? "",
+      adminInviteKey,
       command.topics,
     )
     this.roomRepository.build(room)

--- a/app/server/src/service/room/RestRoomService.ts
+++ b/app/server/src/service/room/RestRoomService.ts
@@ -26,10 +26,10 @@ class RestRoomService {
   }
 
   // Roomに管理者を紐付ける
-  public async invite(command: InviteRoomCommand): Promise<RoomClass> {
+  public async inviteAdmin(command: InviteRoomCommand): Promise<RoomClass> {
     const room = await this.find(command.id)
     // きっとこんな感じになると思っている
-    // room.Invite(command.userId, command.adminInviteKey)
+    room.inviteAdmin(command.userId, command.adminInviteKey)
 
     this.roomRepository.update(room)
     console.log(`new admin invited to room: ${command.id}`)

--- a/app/server/src/service/room/RestRoomService.ts
+++ b/app/server/src/service/room/RestRoomService.ts
@@ -1,6 +1,6 @@
 import IRoomRepository from "../../domain/room/IRoomRepository"
 import RoomClass from "../../domain/room/Room"
-import { BuildRoomCommand } from "./commands"
+import { BuildRoomCommand, InviteRoomCommand } from "./commands"
 import IUserRepository from "../../domain/user/IUserRepository"
 import User from "../../domain/user/User"
 
@@ -21,6 +21,18 @@ class RestRoomService {
     this.roomRepository.build(room)
 
     console.log(`new room build: ${command.id}`)
+
+    return room
+  }
+
+  // Roomに管理者を紐付ける
+  public async invite(command: InviteRoomCommand): Promise<RoomClass> {
+    const room = await this.find(command.id)
+    // きっとこんな感じになると思っている
+    // room.Invite(command.userId, command.adminInviteKey)
+
+    this.roomRepository.update(room)
+    console.log(`new admin invited to room: ${command.id}`)
 
     return room
   }

--- a/app/server/src/service/room/commands.ts
+++ b/app/server/src/service/room/commands.ts
@@ -11,6 +11,7 @@ export type BuildRoomCommand = {
 export type InviteRoomCommand = {
   id: string
   adminInviteKey: string
+  adminId: string
 }
 
 export type ChangeTopicStateCommand = {

--- a/app/server/src/service/room/commands.ts
+++ b/app/server/src/service/room/commands.ts
@@ -8,6 +8,11 @@ export type BuildRoomCommand = {
   description?: string
 }
 
+export type InviteRoomCommand = {
+  id: string
+  adminInviteKey: string
+}
+
 export type ChangeTopicStateCommand = {
   userId: string
   topicId: string


### PR DESCRIPTION
close #xxx

## やったこと

- `app.post("/user/:id/invite"` を作った
- roomServiceにもinviteを作った
- RoomClassにadminIdsとadminInviteKeyを持たせ、正しいkeyならadminIdsにid(仮)を追加しています


## やっていないこと

- データベースには何もやっていないです
- ヘッダーに載っているであろうadminの情報確認(idの取得)も何もしていないです(`post /room` も何もしていない)
- adminInviteKeyはRestRoomServiceで生成していますが、DBに入れていないのでレポジトリの方でfindした時に消えます。この辺りはあとでかな。

> あ、この中だと該当するのないです。最初入らなかったから作ってなかったんですけど、途中であった方良さそうで追加しました。
俺の方でやっとくので、とりあえずアプリケーションサービスの中とかで作っちゃっていいですよ
by 近藤さん

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
