### PR TITLE
API定義を修正

### DIFF
--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -321,11 +321,9 @@ paths:
         '400':
           $ref: '#/responses/Failure'
       description: |-
-        **管理者・一般ユーザ** ユーザー情報を送信し、現在のチャット履歴やスタンプ履歴などを取得する
+        **一般ユーザ** ユーザー情報を送信し、現在のチャット履歴やスタンプ履歴などを取得する
 
         リクエストもレスポンスもあるので注意。
-
-        *※ 管理者の場合は`iconId=0`*
       parameters:
         - in: body
           name: body
@@ -345,6 +343,100 @@ paths:
               - roomId
               - iconId
               - speakerTopicId
+      tags:
+        - SocketIO
+  /ADMIN_ENTER_ROOM:
+    put:
+      summary: ルームに入室する
+      operationId: put-ADMIN_ENTER_ROOM
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: object
+            properties:
+              result:
+                type: string
+                enum:
+                  - success
+              date:
+                type: object
+                properties:
+                  chatItems:
+                    type: array
+                    items:
+                      $ref: '#/definitions/ChatItem'
+                  stamps:
+                    type: array
+                    items:
+                      $ref: '#/definitions/Stamp'
+                  activeUserCount:
+                    type: integer
+                    description: アクティブユーザ数
+                  pinnedChatItemIds:
+                    type: array
+                    description: ピン留めされているChatItemのID
+                    items:
+                      type: string
+                  topicStates:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        topicId:
+                          type: integer
+                        state:
+                          $ref: '#/definitions/TopicState'
+          examples:
+            example:
+              result: success
+              date:
+                chatItems:
+                  - id: 497f6eca-6276-4993-bfeb-53cbbbba6f08
+                    topicId: 0
+                    createdAt: '2019-08-24'
+                    type: message
+                    senderType: general
+                    content: string
+                    quote:
+                      id: 550e8400-e29b-41d4-a716-446655440000
+                      topicId: 0
+                      createdAt: '2019-08-24'
+                      type: message
+                      senderType: general
+                      content: string
+                      timestamp: 0
+                      iconId: 0
+                    timestamp: 0
+                    iconId: 0
+                stamps:
+                  - id: 497f6eca-6276-4993-bfeb-53cbbbba6f08
+                    topicId: 0
+                    timestamp: 0
+                    createdAt: '2019-08-24T14:15:22Z'
+                activeUserCount: 0
+                pinnedChatItemIds:
+                  - string
+                topicStates:
+                  - topicId: 0
+                    state: not-started
+        '400':
+          $ref: '#/responses/Failure'
+      description: |-
+        **管理者** ユーザー情報を送信し、現在のチャット履歴やスタンプ履歴などを取得する
+
+        リクエストもレスポンスもあるので注意。
+      parameters:
+        - in: body
+          name: body
+          schema:
+            type: object
+            properties:
+              roomId:
+                type: string
+                format: uuid
+            required:
+              - roomId
       tags:
         - SocketIO
   /PUB_USER_COUNT:

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: sushi-chat-api
-  version: 1.0.1
+  version: 1.0.2
   description: |-
     sushi-chatのAPI定義です。
 

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -284,9 +284,42 @@ paths:
                         topicId:
                           type: integer
                         state:
-                          $ref: "#/definitions/TopicState"
-        "400":
-          $ref: "#/responses/Failure"
+                          $ref: '#/definitions/TopicState'
+          examples:
+            example:
+              result: success
+              date:
+                chatItems:
+                  - id: 497f6eca-6276-4993-bfeb-53cbbbba6f08
+                    topicId: 0
+                    createdAt: '2019-08-24'
+                    type: message
+                    senderType: general
+                    content: string
+                    quote:
+                      id: 550e8400-e29b-41d4-a716-446655440000
+                      topicId: 0
+                      createdAt: '2019-08-24'
+                      type: message
+                      senderType: general
+                      content: string
+                      timestamp: 0
+                      iconId: 0
+                    timestamp: 0
+                    iconId: 0
+                stamps:
+                  - id: 497f6eca-6276-4993-bfeb-53cbbbba6f08
+                    topicId: 0
+                    timestamp: 0
+                    createdAt: '2019-08-24T14:15:22Z'
+                activeUserCount: 0
+                pinnedChatItemIds:
+                  - string
+                topicStates:
+                  - topicId: 0
+                    state: not-started
+        '400':
+          $ref: '#/responses/Failure'
       description: |-
         **管理者・一般ユーザ** ユーザー情報を送信し、現在のチャット履歴やスタンプ履歴などを取得する
 
@@ -606,6 +639,26 @@ definitions:
       - createdAt
       - type
       - senderType
+    x-examples:
+      example:
+        id: 497f6eca-6276-4993-bfeb-53cbbbba6f08
+        topicId: 0
+        createdAt: '2019-08-24'
+        type: message
+        senderType: general
+        content: 内容
+        quote:
+          id: 497f6eca-6276-4993-bfeb-53cbbbba6f08
+          topicId: 0
+          createdAt: '2019-08-24'
+          type: message
+          senderType: general
+          content: string
+          quote: {}
+          timestamp: 0
+          iconId: 0
+        timestamp: 0
+        iconId: 0
   Stamp:
     title: Stamp
     type: object
@@ -629,9 +682,10 @@ definitions:
     type: string
     title: TopicState
     enum:
-      - OPEN
-      - PAUSE
-      - CLOSE
+      - not-started
+      - ongoing
+      - paused
+      - finished
   ChatItemType:
     type: string
     title: ChatItemType


### PR DESCRIPTION
close #xxx

## やったこと
`TopicState`を
```
enum:
      - OPEN
      - PAUSE
      - CLOSE
```
から
```
enum:
      - not-started
      - ongoing
      - paused
      - finished
```
に変更した（RoomStateとバックエンド実装に近づけて、小文字ハイフン区切りに変更）

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
