### PR TITLE
ルームのヒストリー取得

### DIFF
--- a/app/server/src/domain/room/Room.ts
+++ b/app/server/src/domain/room/Room.ts
@@ -280,6 +280,7 @@ class RoomClass {
     this.assertUserExists(stamp.userId)
 
     this.stampsCount++
+    this._stamps.push(stamp)
   }
 
   /**

--- a/app/server/src/domain/room/Room.ts
+++ b/app/server/src/domain/room/Room.ts
@@ -33,6 +33,14 @@ class RoomClass {
     return [...this._chatItems]
   }
 
+  public get stamps(): Stamp[] {
+    return [...this._stamps]
+  }
+
+  public get pinnedChatItemIds(): string[] {
+    return [...this._pinnedChatItemIds]
+  }
+
   public get isOpened(): boolean {
     return this._state == "ongoing"
   }
@@ -60,6 +68,8 @@ class RoomClass {
     private userIds = new Set<string>([]),
     private adminIds = new Set<string>([]),
     private _chatItems: ChatItem[] = [],
+    private _stamps: Stamp[] = [],
+    private _pinnedChatItemIds: string[] = [],
     private stampsCount = 0,
     private _state: RoomState = "not-started",
   ) {

--- a/app/server/src/infra/repository/room/RoomRepository.ts
+++ b/app/server/src/infra/repository/room/RoomRepository.ts
@@ -114,6 +114,8 @@ class RoomRepository implements IRoomRepository {
       userIds,
       new Set<string>([]) /* これはadminIdsです。 */,
       chatItems,
+      [] /* これはstampsです。 */,
+      [] /* これはpinnedChatItemIdsです。 */,
       stampsCount,
       roomState,
     )

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -66,7 +66,7 @@ export const restSetup = (
         result: "error",
         error: {
           code: 400,
-          message: `${e.message ?? "Unknown error."} (ADMIN_BUILD_ROOM)`,
+          message: `${e.message ?? "Unknown error."} (USER_ROOM_HISTORY)`,
         },
       })
     }

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -48,6 +48,30 @@ export const restSetup = (
     }
   })
 
+  // チャット履歴・スタンプ履歴を取得する
+  app.get("/room/:id/history", async (req, res) => {
+    try {
+      const room = await roomService.find(req.params.id)
+
+      res.send({
+        result: "success",
+        data: {
+          chatItems: room.chatItems,
+          stamps: room.stamps,
+          pinnedChatItemIds: room.pinnedChatItemIds,
+        },
+      })
+    } catch (e) {
+      res.status(400).send({
+        result: "error",
+        error: {
+          code: 400,
+          message: `${e.message ?? "Unknown error."} (ADMIN_BUILD_ROOM)`,
+        },
+      })
+    }
+  })
+
   // ルームと新しい管理者を紐付ける
   app.post("/room/:id/invite", (req, res) => {
     const adminInviteKey = req.query["admin_invite_key"]

--- a/app/server/src/service/room/RestRoomService.ts
+++ b/app/server/src/service/room/RestRoomService.ts
@@ -52,7 +52,7 @@ class RestRoomService {
     this.roomRepository.update(room)
   }
 
-  private async find(roomId: string): Promise<RoomClass> {
+  public async find(roomId: string): Promise<RoomClass> {
     const room = await this.roomRepository.find(roomId)
     if (!room) {
       throw new Error(`[sushi-chat-server] Room(${roomId}) does not exists.`)


### PR DESCRIPTION
close #xxx

## やったこと

get /room/:id/history の実装
合わせて RoomClass に ` _stamps` と `_pinnedChatItemIds` という配列を追加
`_stamps` はスタンプ投稿時に配列に追加する処理も書いている。

## やっていないこと

`_stamps`、`Stamp` 型自体が最新の定義と違うので、完璧なレスポンスにはなっていない。(これはDB周りの変更後に揃うと踏んでいる)

`_pinnedChatItemIds` は空配列が存在するだけ。SocketIO側の変更する時にピン留め処理が増えるはず。

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
