### PR TITLE
Eri 0910/room archive

### DIFF
--- a/app/server/src/domain/room/Room.ts
+++ b/app/server/src/domain/room/Room.ts
@@ -95,8 +95,10 @@ class RoomClass {
 
   /**
    * ルームを閉じる
+   * @param adminId adminのID
    */
-  public archiveRoom = () => {
+  public archiveRoom = (adminId: string) => {
+    this.assertIsAdmin(adminId)
     this.assertRoomIsFinished()
     this._state = "archived"
   }
@@ -360,6 +362,15 @@ class RoomClass {
     if (!same) {
       throw new Error(
         `[sushi-chat-server] adminInviteKey(${adminInviteKey}) does not matches.`,
+      )
+    }
+  }
+
+  private assertIsAdmin(adminId: string) {
+    const exists = this.adminIds.has(adminId)
+    if (!exists) {
+      throw new Error(
+        `[sushi-chat-server] Admin(id: ${adminId}) does not management this room(id:${this.id}).`,
       )
     }
   }

--- a/app/server/src/ioServer.ts
+++ b/app/server/src/ioServer.ts
@@ -1,6 +1,5 @@
 import { Server, Socket } from "socket.io"
 import { Server as HttpServer } from "http"
-import { v4 as uuid } from "uuid"
 import { ReceiveEventParams, ReceiveEventResponses } from "./events"
 import { instrument } from "@socket.io/admin-ui"
 import { createAdapter } from "@socket.io/redis-adapter"
@@ -265,26 +264,6 @@ const createSocketIOServer = async (
         } catch (e) {
           console.error(
             `${e.message ?? "Unknown error."} (ADMIN_FINISH_ROOM)`,
-            new Date().toISOString(),
-          )
-        }
-      })
-
-      // ルームを閉じる
-      socket.on("ADMIN_CLOSE_ROOM", () => {
-        try {
-          const realtimeRoomService = new RealtimeRoomService(
-            roomRepository,
-            userRepository,
-            chatItemRepository,
-            new RoomDelivery(io),
-            new ChatItemDelivery(io),
-            StampDelivery.getInstance(io),
-          )
-          realtimeRoomService.close(socket.id)
-        } catch (e) {
-          console.error(
-            `${e.message ?? "Unknown error."} (ADMIN_CLOSE_ROOM)`,
             new Date().toISOString(),
           )
         }

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -48,6 +48,27 @@ export const restSetup = (
     }
   })
 
+  // ルームを公開停止にする
+  app.put("/room/:id/archive", (req, res) => {
+    // TODO:adminIdをheaderから取得
+    const adminId = ""
+    roomService
+      .archive({
+        id: req.params.id,
+        adminId: adminId,
+      })
+      .then(() => res.send({ result: "success" }))
+      .catch((e) => {
+        res.status(400).send({
+          result: "error",
+          error: {
+            code: 400,
+            message: `${e.message ?? "Unknown error."} (ADMIN_ARCHIVE_ROOM)`,
+          },
+        })
+      })
+  })
+
   // ルームと新しい管理者を紐付ける
   app.post("/room/:id/invite", (req, res) => {
     const adminInviteKey = req.query["admin_invite_key"]

--- a/app/server/src/service/room/RealtimeRoomService.ts
+++ b/app/server/src/service/room/RealtimeRoomService.ts
@@ -42,18 +42,6 @@ class RealtimeRoomService {
     this.roomRepository.update(room)
   }
 
-  // Roomをアーカイブし、閲覧できなくする。RESTのエンドポイントに移行予定
-  public async close(userId: string) {
-    const user = this.findUser(userId)
-    const roomId = user.getRoomIdOrThrow()
-
-    const room = await this.find(roomId)
-    room.archiveRoom()
-
-    this.roomDelivery.close(room.id)
-    this.roomRepository.update(room)
-  }
-
   public async changeTopicState(command: ChangeTopicStateCommand) {
     const user = this.findUser(command.userId)
     const roomId = user.getRoomIdOrThrow()

--- a/app/server/src/service/room/RestRoomService.ts
+++ b/app/server/src/service/room/RestRoomService.ts
@@ -1,6 +1,10 @@
 import IRoomRepository from "../../domain/room/IRoomRepository"
 import RoomClass from "../../domain/room/Room"
-import { BuildRoomCommand, InviteRoomCommand } from "./commands"
+import {
+  ArchiveRoomCommand,
+  BuildRoomCommand,
+  InviteRoomCommand,
+} from "./commands"
 import IUserRepository from "../../domain/user/IUserRepository"
 import User from "../../domain/user/User"
 import { v4 as uuid } from "uuid"
@@ -42,12 +46,9 @@ class RestRoomService {
   }
 
   // Roomをアーカイブし、閲覧できなくする。
-  public async archive(userId: string) {
-    const user = this.findUser(userId)
-    const roomId = user.getRoomIdOrThrow()
-
-    const room = await this.find(roomId)
-    room.archiveRoom()
+  public async archive(command: ArchiveRoomCommand) {
+    const room = await this.find(command.id)
+    room.archiveRoom(command.adminId)
 
     this.roomRepository.update(room)
   }

--- a/app/server/src/service/room/commands.ts
+++ b/app/server/src/service/room/commands.ts
@@ -14,6 +14,11 @@ export type InviteRoomCommand = {
   adminId: string
 }
 
+export type ArchiveRoomCommand = {
+  id: string
+  adminId: string
+}
+
 export type ChangeTopicStateCommand = {
   userId: string
   topicId: string


### PR DESCRIPTION
close #xxx

## やったこと

PUT /room/:id/archive　実装
socketIO側の処理は削除
adminかどうかをassertするやつをRoomClassに追加、アーカイブ処理の前に確認するようにした

## やっていないこと

adminの情報をヘッダーからとってn(以下略

<!--
## スクリーンショット
-->

## 動作確認手順

adminIdをちゃんと保存してないので、普通には確認できません。

RoomRepositoryのfindのreturnのうち、

`new Set<string>([]) /* これはadminIdsです。 */`
を
`new Set<string>([""])`
に、
`roomState`
を
`"finished"`
にすると、一応チェックできます。

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
