### PR TITLE
対応するメッセージまでスクロール/一旦サイドバーを非表示

### DIFF
--- a/app/front/components/ChatRoom.vue
+++ b/app/front/components/ChatRoom.vue
@@ -1,7 +1,8 @@
 <template>
   <article v-if="topic" class="topic-block">
     <TopicHeader
-      :title="topicIndex + '. ' + topic.title"
+      :title="topic.title"
+      :topic-index="topicIndex"
       :topic-state="topicState"
       @download="clickDownload"
     />
@@ -19,6 +20,8 @@
             class="list-complete-item"
           >
             <MessageComponent
+              :message-id="message.id"
+              :topic-id="topicId"
               :message="message"
               @click-thumb-up="clickReaction"
               @click-reply="selectedChatItem = message"

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -3,6 +3,7 @@
     <!-- Message -->
     <article
       v-if="message.type != 'reaction'"
+      :id="messageId"
       class="comment"
       :class="{
         admin: message.iconId == '0',
@@ -67,7 +68,11 @@
     </article>
 
     <!--Reaction Message-->
-    <article v-else-if="message.type == 'reaction'" class="reaction">
+    <article
+      v-else-if="message.type == 'reaction'"
+      :id="messageId"
+      class="reaction"
+    >
       <div class="icon-wrapper">
         <picture>
           <source :srcset="targetIcon.webp" type="image/webp" />
@@ -85,10 +90,13 @@
       <div class="long-text">
         {{ message.target.content }}
       </div>
-      <span class="material-icons"> north_west </span>
+      <!-- targetのmessageにスクロール -->
+      <span class="material-icons" @click="scrolltoMessage(message.target.id)">
+        north_west
+      </span>
     </article>
     <!--System Message-->
-    <!--article class="system_message">
+    <!--article class="system_message" :id="messageId">
       <UrlToLink :text="message.content" />
     </article-->
   </div>
@@ -114,6 +122,14 @@ export default Vue.extend({
       type: Object,
       required: true,
     } as PropOptions<ChatItemPropType>,
+    messageId: {
+      type: String,
+      required: true,
+    },
+    topicId: {
+      type: String,
+      required: true,
+    },
   },
   data(): DataType {
     return {
@@ -135,6 +151,16 @@ export default Vue.extend({
     },
     clickReply() {
       this.$emit("click-reply")
+    },
+    // Reactionから対象のMessageへスクロール
+    scrolltoMessage(id: string) {
+      const element: HTMLElement | null = document.getElementById(id)
+      if (element) {
+        element.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        })
+      }
     },
     // タイムスタンプを分、秒単位に変換
     showTimestamp(timeStamp: number): string {

--- a/app/front/components/TopicHeader.vue
+++ b/app/front/components/TopicHeader.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="topic-header">
     <div class="main-line">
-      <SidebarDrawer
+      <!-- TODO:横スクロールから1セッションへの切り替えが完了するまで非表示 -->
+      <!-- <SidebarDrawer
         :title="'技育CAMPハッカソン vol.5'"
         :description="'2日間(事前開発OK)で成果物を創ってエンジニアとしてレベルアップするオンラインハッカソン。テーマは「無駄開発」。'"
-      />
+      /> -->
       <div class="index">
         #<span style="font-size: 80%">{{ topicIndex }}</span>
       </div>
@@ -24,14 +25,14 @@
 <script lang="ts">
 import Vue from "vue"
 import type { PropOptions } from "vue"
-import SidebarDrawer from "@/components/Sidebar/SidebarDrawer.vue"
+// import SidebarDrawer from "@/components/Sidebar/SidebarDrawer.vue"
 import { TopicState } from "@/models/contents"
 import { UserItemStore } from "~/store"
 
 export default Vue.extend({
   name: "TopicHeader",
   components: {
-    SidebarDrawer,
+    // SidebarDrawer,
   },
   props: {
     title: {


### PR DESCRIPTION
close #301 

## やったこと
- 対応するメッセージまでスクロール
- 一旦サイドバーを非表示
- topicIndexがないと怒られていたヘッダーの修正

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
