### PR TITLE
ルーム作成 API繋ぎ込み

### DIFF
--- a/app/front/components/Home/CreationCompletedModal.vue
+++ b/app/front/components/Home/CreationCompletedModal.vue
@@ -3,6 +3,7 @@
     name="home-creation-completed-modal"
     class="home-creation-completed-modal"
     :click-to-close="false"
+    @before-open="beforeOpen"
   >
     <template #title>イベントが作成されました</template>
     <template #content>
@@ -31,16 +32,12 @@
             class="home-creation-completed-modal__invitation__content__detail"
           >
             <div
-              class="
-                home-creation-completed-modal__invitation__content__detail--url
-              "
+              class=" home-creation-completed-modal__invitation__content__detail--url"
             >
-              https://sushi-chat.com/12345?user=admin
+              https://sushi-chat.com/{{ adminInviteKey }}?user=admin
             </div>
             <button
-              class="
-                home-creation-completed-modal__invitation__content__detail--button
-              "
+              class=" home-creation-completed-modal__invitation__content__detail--button"
             >
               コピーする
             </button>
@@ -58,11 +55,26 @@
 import Vue from "vue"
 import Modal from "@/components/Home/Modal.vue"
 
+type Data = {
+  adminInviteKey: string | null
+}
+
 export default Vue.extend({
   name: "HomeCreationCompletedModal",
   components: {
     Modal,
   },
   layout: "home",
+  data(): Data {
+    return {
+      adminInviteKey: null,
+    }
+  },
+  methods: {
+    beforeOpen(event: any) {
+      console.log(event)
+      this.adminInviteKey = event.params.time
+    },
+  },
 })
 </script>

--- a/app/front/pages/room/create.vue
+++ b/app/front/pages/room/create.vue
@@ -3,7 +3,7 @@
     <header class="home-create__header">イベントの作成</header>
     <section class="home-create__event-name">
       <div class="home-create__event-name--title">1.イベント名の入力</div>
-      <input class="home-create__event-name--input" />
+      <input v-model="roomName" class="home-create__event-name--input" />
     </section>
     <section class="home-create__room">
       <div class="home-create__room--title">2.ルームの登録</div>
@@ -67,10 +67,7 @@
         </div>
       </div>
     </section>
-    <button
-      class="home-create__create-new-event-button"
-      @click="$modal.show('home-creation-completed-modal')"
-    >
+    <button class="home-create__create-new-event-button" @click="createRoom">
       この内容で作成
     </button>
     <AddSessionsModal />
@@ -87,6 +84,7 @@ import CreationCompletedModal from "@/components/Home/CreationCompletedModal.vue
 
 Vue.use(VModal)
 type DataType = {
+  roomName: string
   sessionList: { name: string; id: number }[]
   isDragging: boolean
 }
@@ -100,6 +98,7 @@ export default Vue.extend({
   layout: "home",
   data(): DataType {
     return {
+      roomName: "",
       sessionList: [
         { name: "いけおく", id: 0 },
         { name: "池奥", id: 1 },
@@ -126,6 +125,31 @@ export default Vue.extend({
     },
     removeSession(idx: number) {
       this.sessionList.splice(idx, 1)
+    },
+    async createRoom() {
+      try {
+        const sessions = this.sessionList
+        const res = await this.$apiClient.post("/room", {
+          name: this.roomName,
+          topics: sessions,
+          description: "hello, world",
+        })
+
+        if (res.result === "error") {
+          throw new Error("エラーが発生しました")
+        }
+
+        console.log(res)
+        // @ts-ignore
+        const createdRoom = res.room[0]
+
+        this.$modal.show("home-creation-completed-modal", {
+          adminInviteKey: createdRoom.adminInviteKey,
+        })
+      } catch (e) {
+        console.error(e)
+        window.alert("エラーが発生しました")
+      }
     },
   },
 })

--- a/app/front/pages/room/create.vue
+++ b/app/front/pages/room/create.vue
@@ -125,7 +125,15 @@ export default Vue.extend({
     },
     async createRoom() {
       try {
-        const sessions = this.sessionList
+        // titleのないセッションは無視
+        const sessions = this.sessionList.filter(
+          (session) => session.title !== "",
+        )
+        // room名とセッションが不足していたらエラー
+        if (this.roomName === "" || sessions.length === 0) {
+          throw new Error("入力が不足しています")
+        }
+
         const res = await this.$apiClient.post("/room", {
           title: this.roomName,
           topics: sessions,
@@ -136,15 +144,16 @@ export default Vue.extend({
           throw new Error("エラーが発生しました")
         }
 
-        console.log(res)
         const createdRoom = res.data
 
         this.$modal.show("home-creation-completed-modal", {
+          title: createdRoom.title,
+          id: createdRoom.id,
           adminInviteKey: createdRoom.adminInviteKey,
         })
       } catch (e) {
         console.error(e)
-        window.alert("エラーが発生しました")
+        window.alert(e.message ?? "不明なエラーが発生しました")
       }
     },
   },

--- a/app/front/pages/room/create.vue
+++ b/app/front/pages/room/create.vue
@@ -33,7 +33,10 @@
                 class="home-create__room__sessions__list--element"
               >
                 <div class="home-create__room__sessions__list--element--input">
-                  <input v-model="list.name" placeholder="セッション名を入力" />
+                  <input
+                    v-model="list.title"
+                    placeholder="セッション名を入力"
+                  />
                   <div
                     class="home-create__room__sessions__list--element--remove"
                     @click="removeSession(idx)"
@@ -85,7 +88,7 @@ import CreationCompletedModal from "@/components/Home/CreationCompletedModal.vue
 Vue.use(VModal)
 type DataType = {
   roomName: string
-  sessionList: { name: string; id: number }[]
+  sessionList: { title: string; id: number }[]
   isDragging: boolean
 }
 export default Vue.extend({
@@ -99,13 +102,7 @@ export default Vue.extend({
   data(): DataType {
     return {
       roomName: "",
-      sessionList: [
-        { name: "いけおく", id: 0 },
-        { name: "池奥", id: 1 },
-        { name: "Ikeoku", id: 2 },
-        { name: "寿司処いけおく", id: 3 },
-        { name: "大乱闘いけおくブラザーズ", id: 4 },
-      ],
+      sessionList: [{ title: "", id: 1 }],
       isDragging: false,
     }
   },
@@ -121,7 +118,7 @@ export default Vue.extend({
   },
   methods: {
     addSession() {
-      this.sessionList.push({ name: "", id: this.sessionList.length - 1 })
+      this.sessionList.push({ title: "", id: this.sessionList.length - 1 })
     },
     removeSession(idx: number) {
       this.sessionList.splice(idx, 1)
@@ -130,7 +127,7 @@ export default Vue.extend({
       try {
         const sessions = this.sessionList
         const res = await this.$apiClient.post("/room", {
-          name: this.roomName,
+          title: this.roomName,
           topics: sessions,
           description: "hello, world",
         })

--- a/app/front/pages/room/create.vue
+++ b/app/front/pages/room/create.vue
@@ -102,7 +102,7 @@ export default Vue.extend({
   data(): DataType {
     return {
       roomName: "",
-      sessionList: [{ title: "", id: 1 }],
+      sessionList: [{ title: "", id: 0 }],
       isDragging: false,
     }
   },
@@ -118,7 +118,7 @@ export default Vue.extend({
   },
   methods: {
     addSession() {
-      this.sessionList.push({ title: "", id: this.sessionList.length - 1 })
+      this.sessionList.push({ title: "", id: this.sessionList.length })
     },
     removeSession(idx: number) {
       this.sessionList.splice(idx, 1)

--- a/app/front/pages/room/create.vue
+++ b/app/front/pages/room/create.vue
@@ -137,8 +137,7 @@ export default Vue.extend({
         }
 
         console.log(res)
-        // @ts-ignore
-        const createdRoom = res.room[0]
+        const createdRoom = res.data
 
         this.$modal.show("home-creation-completed-modal", {
           adminInviteKey: createdRoom.adminInviteKey,

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -55,19 +55,15 @@ export const restSetup = (
 
       res.send({
         result: "success",
-        room: [
-          {
-            id: newRoom.id,
-            title: newRoom.title,
-            description: newRoom.description,
-            topics: newRoom.topics,
-            state: newRoom.state,
-            adminInviteKey: newRoom.adminInviteKey,
-            /*
-              startDate: newRoom.startDate,
-              */
-          },
-        ],
+        data: {
+          id: newRoom.id,
+          title: newRoom.title,
+          description: newRoom.description,
+          topics: newRoom.topics,
+          state: newRoom.state,
+          adminInviteKey: newRoom.adminInviteKey,
+          startDate: newRoom.startAt?.getDate(),
+        },
       })
     } catch (e) {
       res.status(400).send({

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -52,7 +52,6 @@ export const restSetup = (
         topics: req.body.topics,
         description: req.body.description,
       })
-
       res.send({
         result: "success",
         data: {
@@ -62,7 +61,7 @@ export const restSetup = (
           topics: newRoom.topics,
           state: newRoom.state,
           adminInviteKey: newRoom.adminInviteKey,
-          startDate: newRoom.startAt?.getDate(),
+          startDate: null,
         },
       })
     } catch (e) {

--- a/app/shared/src/types/rest.ts
+++ b/app/shared/src/types/rest.ts
@@ -30,7 +30,7 @@ export type RestApiDefinition = {
           }[]
           description?: string
         }
-        response: SuccessResponse<RoomModel[]> | ErrorResponse
+        response: SuccessResponse<RoomModel> | ErrorResponse
       }
     }
   }

--- a/app/shared/src/types/rest.ts
+++ b/app/shared/src/types/rest.ts
@@ -141,8 +141,8 @@ export type PutMethodPath = PathsWithMethod<"put">
 export type RestApi<
   Method extends "get" | "post" | "put",
   Path extends keyof RestApiDefinition,
-> = Path extends GetMethodPath
-  ? Method extends "get"
+> = Method extends "get"
+  ? Path extends GetMethodPath
     ? {
         request: RestApiDefinition[Path]["methods"]["get"]["request"]
         response: RestApiDefinition[Path]["methods"]["get"]["response"]
@@ -150,8 +150,8 @@ export type RestApi<
         query: RestApiDefinition[Path]["methods"]["get"]["query"]
       }
     : never
-  : Path extends PostMethodPath
-  ? Method extends "post"
+  : Method extends "post"
+  ? Path extends PostMethodPath
     ? {
         request: RestApiDefinition[Path]["methods"]["post"]["request"]
         response: RestApiDefinition[Path]["methods"]["post"]["response"]
@@ -159,8 +159,8 @@ export type RestApi<
         query: RestApiDefinition[Path]["methods"]["post"]["query"]
       }
     : never
-  : Path extends PutMethodPath
-  ? Method extends "put"
+  : Method extends "put"
+  ? Path extends PutMethodPath
     ? {
         request: RestApiDefinition[Path]["methods"]["put"]["request"]
         response: RestApiDefinition[Path]["methods"]["put"]["response"]

--- a/app/shared/src/types/rest.ts
+++ b/app/shared/src/types/rest.ts
@@ -24,9 +24,9 @@ export type RestApiDefinition = {
       post: {
         query: Empty
         request: {
-          name: string
+          title: string
           topics: {
-            name: string
+            title: string
           }[]
           description?: string
         }


### PR DESCRIPTION
close #xxx

## やったこと

「この内容で作成」を押したときにルームを作成する、一応軽くバリデーション付き
型の修正

sessionに初期値入ってたの消した
idがなんか合わなかったので修正した

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

## 既知のバグ（別PRで対応するものなど）

モーダルでbefore-openが呼び出されないので、値が渡せない。
/homeでルーム名入れてボタン押しても、次の画面に引き継がれていない
safariやっぱりボタン変
description入力欄がない
サーバーadminの登録ができていない(近藤さんタスク？)


## 参考リンク・補足など
