### PR TITLE
寿司選択画面に情報を追加

### DIFF
--- a/app/front/assets/scss/common.scss
+++ b/app/front/assets/scss/common.scss
@@ -4,6 +4,7 @@ body {
   -webkit-font-smoothing: antialiased;
   color: $black;
   font-size: 0.9rem;
+  background: #f8f8f8;
 }
 
 .material-icons {

--- a/app/front/assets/scss/sushiselect.scss
+++ b/app/front/assets/scss/sushiselect.scss
@@ -103,7 +103,7 @@
     /* アイコン選択モーダル */
     &--icon-list {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
       padding: 0;
       margin: 0;
       margin-bottom: 32px;
@@ -113,8 +113,8 @@
       border-radius: 4px;
 
       & > .icon-box {
-        // width: 80px;
-        // height: 80px;
+        width: 80px;
+        height: 80px;
         box-sizing: border-box;
         display: flex;
         border-radius: 100%;

--- a/app/front/assets/scss/sushiselect.scss
+++ b/app/front/assets/scss/sushiselect.scss
@@ -26,6 +26,7 @@
   width: 100vw;
   height: 100vh;
   @include sushi-select-layout(1);
+  margin-bottom: 0;
   padding-top: 3rem;
   @media screen and (min-width: $small+px) {
     padding-top: 5rem;
@@ -36,10 +37,10 @@
     // background-color: white;
     padding: 36px 0;
     @media screen and (min-width: $small+px) {
-      padding: 36px;
+      padding: 0;
     }
     border-radius: 4px;
-    margin-bottom: 36px;
+    margin-bottom: 64px;
     &--title {
       @include text-size(lg);
       margin-bottom: 10px;
@@ -87,7 +88,8 @@
       }
     }
     &--speaker {
-      width: 100%;
+      max-width: 100%;
+      width: 400px;
       padding: 10px 10px;
       border: 1px solid transparent;
       border-radius: 10px;

--- a/app/front/assets/scss/sushiselect.scss
+++ b/app/front/assets/scss/sushiselect.scss
@@ -1,28 +1,28 @@
-@mixin sushi-select-layout($py:0) {
-  padding: $py+rem 5%;
+@mixin sushi-select-layout($py: 0) {
+  padding: $py + rem 5%;
   margin-bottom: 2rem;
   @media screen and (min-width: $small+px) {
-    padding: $py+rem 20%;
+    padding: $py + rem 20%;
   }
   @media screen and (min-width: $large+px) {
-    padding: $py+rem 20%;
+    padding: $py + rem 20%;
   }
 }
-  
-@mixin sushi-select-card{
+
+@mixin sushi-select-card {
   padding: 20px;
   background-color: white;
-  &--title{
+  &--title {
     @include text-size(lg);
     margin-bottom: 10px;
   }
-  &--content{
+  &--content {
     color: #515151;
-  }    
+  }
 }
 
-.sushi-select{
-  background-color: #F8F8F8;
+.sushi-select {
+  background-color: #f8f8f8;
   width: 100vw;
   height: 100vh;
   @include sushi-select-layout(1);
@@ -31,25 +31,47 @@
     padding-top: 5rem;
   }
 
-  &__section{
+  &__header {
+    color: #515151;
+    // background-color: white;
+    padding: 36px 0;
+    @media screen and (min-width: $small+px) {
+      padding: 36px;
+    }
+    border-radius: 4px;
+    margin-bottom: 36px;
+    &--title {
+      @include text-size(lg);
+      margin-bottom: 10px;
+    }
+  }
+
+  &__section {
     display: flex;
-    &--title{
+
+    & > article {
+      flex-grow: 1;
+    }
+
+    &--title {
       @include text-size("lg");
       color: $text-gray;
       margin-bottom: 0.5rem;
     }
-    &--help{
+    &--help {
       position: relative;
-      .material-icons{
+      .material-icons {
         margin-left: 0.5rem;
         display: inline-flex !important;
         vertical-align: middle;
-        &:hover{
+        font-size: 1rem;
+
+        &:hover {
           cursor: pointer;
           color: $primary;
         }
       }
-      &--message{
+      &--message {
         display: none;
         position: absolute;
         left: 10px;
@@ -64,25 +86,35 @@
         display: block;
       }
     }
-    &--speaker{
+    &--speaker {
       width: 100%;
-      padding: 5px 10px;
-      border: none;
+      padding: 10px 10px;
+      border: 1px solid transparent;
+      border-radius: 10px;
       outline: none;
       margin-bottom: 50px;
+      cursor: pointer;
+      @include text-size("normal");
+
+      &:focus-visible {
+        border-color: rgb(214, 214, 214);
+      }
     }
     /* アイコン選択モーダル */
-     &--icon-list {
+    &--icon-list {
       display: grid;
-      grid-template-columns: repeat(6, 1fr);
-      grid-auto-rows: 1fr;
+      grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
       padding: 0;
       margin: 0;
+      margin-bottom: 32px;
       list-style-type: none;
       background-color: white;
-      @include sushi-select-layout(1);
-    
+      padding: 12px;
+      border-radius: 4px;
+
       & > .icon-box {
+        width: 80px;
+        height: 80px;
         box-sizing: border-box;
         display: flex;
         border-radius: 100%;
@@ -91,15 +123,12 @@
         object-fit: contain;
         position: relative;
         border: solid 3px transparent;
-        padding: 4px;
-        margin: 2px;
+        padding: 8px;
         background: white;
         transition: all 0.2s;
-        @media screen and (min-width: $large+px) {
-          border: solid 5px transparent;
-        }
+        margin: 12px;
       }
-    
+
       & > .icon-box:hover {
         background: rgb(245, 245, 245);
       }
@@ -107,17 +136,17 @@
         opacity: 0.1;
       }
       & > .icon-selected {
-        border-color: #ae1f23;
+        border-color: $primary;
         opacity: 1;
       }
     }
-    &--start{
+    &--start {
       display: flex;
       margin-top: 1rem;
     }
-    &--button{
+    &--button {
       align-self: center;
-      margin-left: 1rem;
+      margin-left: 2rem;
       button {
         @include home-button-text($primary);
       }
@@ -125,12 +154,12 @@
         margin-left: 3rem;
       }
     }
-    &--my-sushi{
-      width: 50px;
-      height: 50px;
+    &--my-sushi {
+      width: 80px;
+      height: 80px;
       padding: 10px;
       border-radius: 16px;
-      background: #F2F2F2;
+      background: #f2f2f2;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -142,17 +171,20 @@
     }
   }
 
-  &__progressbar{
+  &__progressbar {
     width: 24px;
-    margin-right: 10px;
+    // margin-right: 0px;
+    display: none;
     @media screen and (min-width: $small+px) {
       margin-right: 20px;
+      display: block;
     }
     @media screen and (min-width: $large+px) {
       margin-right: 30px;
       width: 34px;
+      display: block;
     }
-    &--circle{
+    &--circle {
       width: 24px;
       height: 24px;
       background-color: $primary;
@@ -162,25 +194,25 @@
         height: 34px;
       }
     }
-    &--line{
+    &--line {
       width: 3px;
       height: 100%;
       margin: 0 auto;
       background-color: $primary;
       @media screen and (min-width: $small+px) {
-        width: 4px;
+        width: 3px;
       }
       @media screen and (min-width: $large+px) {
         width: 5px;
       }
     }
-  } 
+  }
 }
 
-.not-found{
+.not-found {
   display: flex;
   flex-direction: column;
-  &__icon{
+  &__icon {
     width: 100px;
     height: 100px;
     padding: 10px;
@@ -196,30 +228,30 @@
       padding: 10px;
     }
   }
-  &__textbox{
+  &__textbox {
     @include sushi-select-card;
   }
 }
 
-.not-started{
+.not-started {
   display: flex;
   flex-direction: column;
-  &__title{
+  &__title {
     @include text-size(lg);
     color: $text-gray;
     align-self: center;
     margin-bottom: 2rem;
   }
-  &__textbox{
+  &__textbox {
     @include sushi-select-card;
   }
-  &__warning{
+  &__warning {
     text-align: center;
-    color: #FF0000;
+    color: #ff0000;
     margin: 2rem 0;
   }
-  &__button{
-    button{
+  &__button {
+    button {
       margin: 0 auto;
       @include home-button-text($primary);
     }

--- a/app/front/assets/scss/sushiselect.scss
+++ b/app/front/assets/scss/sushiselect.scss
@@ -143,6 +143,7 @@
     &--start {
       display: flex;
       margin-top: 1rem;
+      margin-bottom: 48px;
     }
     &--button {
       align-self: center;

--- a/app/front/assets/scss/sushiselect.scss
+++ b/app/front/assets/scss/sushiselect.scss
@@ -113,8 +113,8 @@
       border-radius: 4px;
 
       & > .icon-box {
-        width: 80px;
-        height: 80px;
+        // width: 80px;
+        // height: 80px;
         box-sizing: border-box;
         display: flex;
         border-radius: 100%;
@@ -126,7 +126,7 @@
         padding: 8px;
         background: white;
         transition: all 0.2s;
-        margin: 12px;
+        margin: 4px;
       }
 
       & > .icon-box:hover {
@@ -147,12 +147,12 @@
     }
     &--button {
       align-self: center;
-      margin-left: 2rem;
+      margin-left: 1rem;
       button {
         @include home-button-text($primary);
       }
       @media screen and (min-width: $large+px) {
-        margin-left: 3rem;
+        margin-left: 2rem;
       }
     }
     &--my-sushi {
@@ -165,10 +165,6 @@
       align-items: center;
       justify-content: center;
       object-fit: contain;
-      @media screen and (min-width: $large+px) {
-        width: 70px;
-        height: 70px;
-      }
     }
   }
 

--- a/app/front/components/SelectIconModal.vue
+++ b/app/front/components/SelectIconModal.vue
@@ -1,5 +1,12 @@
 <template>
   <div class="sushi-select">
+    <section class="sushi-select__header">
+      <h1 class="sushi-select__header--title">技育ハッカソンvol7</h1>
+      <p class="sushi-select__header--content">
+        2日間(事前開発OK)で成果物を創ってエンジニアとしてレベルアップするオンラインハッカソン。テーマは「無駄開発」。
+      </p>
+    </section>
+
     <section class="sushi-select__section">
       <div class="sushi-select__progressbar">
         <div class="sushi-select__progressbar--circle" />


### PR DESCRIPTION
close #xxx

## やったこと
- 寿司選択画面にルーム名と説明を追加
  - レスポンシブ考慮済み 
- 寿司一覧のCSSを変更（アイコンのサイズが極小になるケースがあったので、サイズを固定にしました！）
- SP時に、横の線と●が表示されないように変更

<!--
## やっていないこと
-->


## スクリーンショット

![image](https://user-images.githubusercontent.com/38308823/134482975-fbf7cbe2-d8d1-4e0b-94c6-87ca09452a4d.png)


![image](https://user-images.githubusercontent.com/38308823/134482456-a2827190-304b-4cef-aa15-12e874bbbd04.png)



<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
