### PR TITLE
ルーム作成完了モーダルの招待URLボタン

### DIFF
--- a/app/front/assets/scss/home/home.scss
+++ b/app/front/assets/scss/home/home.scss
@@ -275,6 +275,7 @@
           align-items: flex-start;
         }
         &--url{
+          word-break : break-all;
           @media screen and (min-width: $small+px) {
             flex: 1;
 	          overflow-x: scroll;
@@ -285,6 +286,10 @@
           background:rgba(255, 255, 255, 0);
           color: $admin-primary;
           padding: 0;
+          margin-left: 5px;
+          .material-icons{
+            font-size: 18px;
+          }
         }
       }
     }

--- a/app/front/components/Home/CreationCompletedModal.vue
+++ b/app/front/components/Home/CreationCompletedModal.vue
@@ -12,15 +12,20 @@
       </section>
       <section class="home-creation-completed-modal__event-detail">
         <div class="home-creation-completed-modal__event-detail--description">
-          <NuxtLink to="/">イベントページをみる→</NuxtLink>
+          <NuxtLink :to="'/?user=admin&roomId=' + roomId"
+            >イベントページをみる→</NuxtLink
+          >
         </div>
         <div class="home-creation-completed-modal__event-detail--additional">
           （イベントページはマイページからも確認できます）
         </div>
       </section>
-      <section class="home-creation-completed-modal__invitation">
+      <section
+        class="home-creation-completed-modal__invitation"
+        style="margin-bottom: 1rem"
+      >
         <div class="home-creation-completed-modal__invitation--title">
-          共同管理者を招待する
+          🍣 参加者を招待する
         </div>
         <div class="home-creation-completed-modal__invitation__content">
           <div
@@ -32,14 +37,54 @@
             class="home-creation-completed-modal__invitation__content__detail"
           >
             <div
-              class=" home-creation-completed-modal__invitation__content__detail--url"
+              class="
+                home-creation-completed-modal__invitation__content__detail--url
+              "
             >
-              https://sushi-chat.com/{{ adminInviteKey }}?user=admin
+              {{ url }}
             </div>
             <button
-              class=" home-creation-completed-modal__invitation__content__detail--button"
+              class="
+                home-creation-completed-modal__invitation__content__detail--button
+              "
+              @click="copy(url, 0)"
             >
-              コピーする
+              <span v-if="copyCompleted" class="material-icons"> done </span>
+              <span v-else class="material-icons"> content_copy </span>
+            </button>
+          </div>
+        </div>
+      </section>
+      <section class="home-creation-completed-modal__invitation">
+        <div class="home-creation-completed-modal__invitation--title">
+          🍣 共同管理者を招待する
+        </div>
+        <div class="home-creation-completed-modal__invitation__content">
+          <div
+            class="home-creation-completed-modal__invitation__content--title"
+          >
+            招待リンク
+          </div>
+          <div
+            class="home-creation-completed-modal__invitation__content__detail"
+          >
+            <div
+              class="
+                home-creation-completed-modal__invitation__content__detail--url
+              "
+            >
+              {{ adminUrl }}
+            </div>
+            <button
+              class="
+                home-creation-completed-modal__invitation__content__detail--button
+              "
+              @click="copy(adminUrl, 1)"
+            >
+              <span v-if="copyAdminCompleted" class="material-icons">
+                done
+              </span>
+              <span v-else class="material-icons"> content_copy </span>
             </button>
           </div>
         </div>
@@ -55,8 +100,11 @@
 import Vue from "vue"
 import Modal from "@/components/Home/Modal.vue"
 
-type Data = {
+type DataType = {
   adminInviteKey: string | null
+  roomId: string | null
+  copyCompleted: boolean
+  copyAdminCompleted: boolean
 }
 
 export default Vue.extend({
@@ -65,15 +113,39 @@ export default Vue.extend({
     Modal,
   },
   layout: "home",
-  data(): Data {
+  data(): DataType {
     return {
       adminInviteKey: null,
+      roomId: null,
+      copyCompleted: false,
+      copyAdminCompleted: false,
     }
+  },
+  computed: {
+    url(): string {
+      return `${location.origin}/?roomId=${this.roomId}`
+    },
+    adminUrl(): string {
+      return `${location.origin}/?user=admin&roomId=${this.roomId}`
+    },
   },
   methods: {
     beforeOpen(event: any) {
-      console.log(event)
-      this.adminInviteKey = event.params.time
+      this.roomId = event.params.id
+    },
+    copy(s: string, idx: number) {
+      navigator.clipboard.writeText(s)
+      if (idx === 0) {
+        this.copyCompleted = true
+        setTimeout(() => {
+          this.copyCompleted = false
+        }, 2000)
+      } else {
+        this.copyAdminCompleted = true
+        setTimeout(() => {
+          this.copyAdminCompleted = false
+        }, 2000)
+      }
     },
   },
 })

--- a/app/front/components/Home/Modal.vue
+++ b/app/front/components/Home/Modal.vue
@@ -6,6 +6,7 @@
     :width="width"
     height="auto"
     :click-to-close="clickToClose"
+    @before-open="beforeOpen"
   >
     <div class="home-modal__header">
       <slot name="title" />
@@ -45,6 +46,11 @@ export default Vue.extend({
       } else {
         return "50%"
       }
+    },
+  },
+  methods: {
+    beforeOpen(event: any) {
+      this.$emit("before-open", event)
     },
   },
 })


### PR DESCRIPTION
close #345 
close #345 

## やったこと
ルーム作成完了モーダルの招待URLの値を入れた
コピーボタンを作った：コピーマーク→押すと２秒間✅→コピーマークに戻る

<!--
## やっていないこと
-->

## スクリーンショット
<img width="809" alt="スクリーンショット 2021-09-23 18 38 15" src="https://user-images.githubusercontent.com/65712721/134485702-98fd6f77-dc05-47d7-bff4-3b3860aa3305.png">
<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
