### PR TITLE
ヘッダー3点リーダ内のUI

### DIFF
--- a/app/front/assets/scss/app.scss
+++ b/app/front/assets/scss/app.scss
@@ -3,8 +3,8 @@
 @import "common";
 
 // Page
-@import "index";
 @import "home/app";
+@import "index";
 
 // Components
 @import "admin";

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -1,3 +1,30 @@
+@mixin rounded-button($color:$primary){
+  color: $color;
+  border: 2px solid;
+  background-color: white;
+  padding: 0px 20px;
+  border-radius: 99px;
+  white-space: nowrap;
+  &:hover{
+    @if $color == $primary{
+      background-color: rgba(242, 141, 47, 0.2);
+    }
+  }
+  &.selected{
+    color: white;
+    background-color: $color;
+    border-color: $color;
+  }
+}
+
+@mixin material-icons-in-text{
+  .material-icons{
+    display: inline-flex !important;
+    vertical-align: middle;
+  }
+}
+
+
 .topic-block {
   white-space: normal;
   height: 100%;
@@ -20,7 +47,9 @@
   position: relative;
 
   & > .main-line {
+    z-index: 1;
     display: flex;
+    position: relative;
     align-items: center;
     padding: 0.2em 0.3em 0;
     background-color: $primary;
@@ -69,6 +98,40 @@
       & > .material-icons {
         font-size: 1.5em;
       }
+    }
+  }
+
+  &__details{
+    position: relative;
+    z-index: 0;
+    background-color: white;
+    padding: 15px;
+    box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.25);
+    &--filter-btn{
+      @include rounded-button;
+      margin-bottom: 10px;
+    }
+    &--description{
+      color: $text-gray;
+      @include text-size($size:"sm");
+    }
+    &--line{
+      width: 100%;
+      height: 2px;
+      margin: 10px 0;
+      background-color: $placeholder-gray;
+    }
+    &--download{
+      color: $admin-primary;
+      cursor: pointer;
+      &>.material-icons{
+        font-size: 1rem;
+      }
+      &>.text{
+        text-decoration: underline;
+      }
+      @include text-size($size:"sm");
+      @include material-icons-in-text;
     }
   }
 }

--- a/app/front/assets/scss/sushiselect.scss
+++ b/app/front/assets/scss/sushiselect.scss
@@ -61,12 +61,10 @@
     }
     &--help {
       position: relative;
+      @include material-icons-in-text;
       .material-icons {
         margin-left: 0.5rem;
-        display: inline-flex !important;
-        vertical-align: middle;
         font-size: 1rem;
-
         &:hover {
           cursor: pointer;
           color: $primary;

--- a/app/front/components/TopicHeader.vue
+++ b/app/front/components/TopicHeader.vue
@@ -10,15 +10,34 @@
         #<span style="font-size: 80%">{{ topicIndex }}</span>
       </div>
       <div class="title">{{ title }}</div>
-      <button class="link-button">
-        <span class="material-icons"> link </span>
-      </button>
-      <button class="more-button">
+      <button class="more-button" @click="isOpenDetails = !isOpenDetails">
         <span class="material-icons"> more_vert </span>
       </button>
-      <!--button class="download-button" @click="clickDownload">
-        <download-icon size="18"></download-icon>
-      </button-->
+    </div>
+    <div v-if="isOpenDetails" class="topic-header__details">
+      <button
+        class="topic-header__details--filter-btn"
+        :class="{ selected: isAllCommentShowed === true }"
+        @click="isAllCommentShowed = true"
+      >
+        すべて
+      </button>
+      <button
+        class="topic-header__details--filter-btn"
+        :class="{ selected: isAllCommentShowed === false }"
+        @click="isAllCommentShowed = false"
+      >
+        質問と回答
+      </button>
+      <div class="topic-header__details--description">
+        質問と回答：
+        質問と回答のみ表示されます（運営やスピーカーの投稿も表示されます）
+      </div>
+      <div class="topic-header__details--line" />
+      <div class="topic-header__details--download" @click="clickDownload">
+        <span class="material-icons"> file_download </span>
+        <span class="text">現在までのチャット履歴のダウンロード</span>
+      </div>
     </div>
   </div>
 </template>
@@ -28,6 +47,11 @@ import type { PropOptions } from "vue"
 // import SidebarDrawer from "@/components/Sidebar/SidebarDrawer.vue"
 import { TopicState } from "@/models/contents"
 import { UserItemStore } from "~/store"
+
+type DataType = {
+  isAllCommentShowed: boolean
+  isOpenDetails: boolean
+}
 
 export default Vue.extend({
   name: "TopicHeader",
@@ -47,6 +71,12 @@ export default Vue.extend({
       type: Number,
       required: true,
     },
+  },
+  data(): DataType {
+    return {
+      isAllCommentShowed: true,
+      isOpenDetails: false,
+    }
   },
   computed: {
     isAdmin(): boolean {


### PR DESCRIPTION
close #318 

## やったこと
- ヘッダー3点リーダ内のUI

## やっていないこと
- ダウンロードボタンの挙動確認
- アクティブユーザー表示
- 繋ぎこみ

## スクリーンショット
<img width="612" alt="スクリーンショット 2021-09-23 23 35 22" src="https://user-images.githubusercontent.com/65712721/134527744-1c194c09-99f5-4e55-857d-8e2bfc1cc39d.png">

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
