### PR TITLE
API呼び出し時にトークンがセットされる実装

### DIFF
--- a/app/front/apiClient/index.ts
+++ b/app/front/apiClient/index.ts
@@ -55,8 +55,12 @@ export default class Repository {
    * idTokenを設定する
    * @param idToken idToken
    */
-  public setToken(idToken: string) {
-    this.nuxtAxios.setToken(idToken)
+  public setToken(idToken: string | null) {
+    if (idToken != null) {
+      this.nuxtAxios.setToken(`Bearer ${idToken}`)
+    } else {
+      this.nuxtAxios.setToken(false)
+    }
   }
 
   /**

--- a/app/front/assets/scss/home/variables.scss
+++ b/app/front/assets/scss/home/variables.scss
@@ -1,50 +1,48 @@
-@mixin home-padding-layout($py:0) {
-  padding: $py+rem 5%;
+@mixin home-padding-layout($py: 0) {
+  padding: $py + rem 5%;
   margin-bottom: 2rem;
   @media screen and (min-width: $small+px) {
-    padding: $py+rem 10%;
+    padding: $py + rem 10%;
   }
   @media screen and (min-width: $large+px) {
-    padding: $py+rem 20%;
+    padding: $py + rem 20%;
   }
 }
 
-@mixin home-button-text($color:$admin-primary){
+@mixin home-button-text($color: $admin-primary) {
   display: flex;
   align-items: center;
   color: $color;
   border: 2px solid;
   border-radius: 4px;
-  background:rgba(255, 255, 255, 0);
+  background: rgba(255, 255, 255, 0);
   padding: 8px 20px;
-  text-decoration:none;
+  text-decoration: none;
   white-space: nowrap;
-  .material-icons{
+  .material-icons {
     margin-left: -3px;
   }
-  a{
+  a {
     display: flex;
     align-items: center;
   }
-  &:hover,&:focus{
+  &:hover,
+  &:focus {
     @if $color == $admin-primary {
-      background-color: rgba(112,145,195,0.2);
-    }
-    @else if $color == $danger{
-      background-color: rgba(225,147,147,0.2);
-    }
-    @else if $color == $primary{
+      background-color: rgba(112, 145, 195, 0.2);
+    } @else if $color == $danger {
+      background-color: rgba(225, 147, 147, 0.2);
+    } @else if $color == $primary {
       background-color: rgba(242, 141, 47, 0.2);
     }
   }
   @include invalidated-a-style;
 }
 
-@mixin text-size($size:"normal"){
-  @if $size=="normal"{
+@mixin text-size($size: "normal") {
+  @if $size== "normal" {
     font-size: 0.9rem;
-  }
-  @else if $size=="xl"{
+  } @else if $size== "xl" {
     font-size: 1rem;
     @media screen and (min-width: $small+px) {
       font-size: 1.5rem;
@@ -52,62 +50,62 @@
     @media screen and (min-width: $large+px) {
       font-size: 1.5rem;
     }
-  }
-  @else if $size=="lg"{
+  } @else if $size== "lg" {
     font-size: 1.2rem;
-  }
-  @else if $size=="mdi"{
+  } @else if $size== "mdi" {
     font-size: 1rem;
-  }
-  @else if $size=="sm"{
+  } @else if $size== "sm" {
     font-size: 0.7rem;
   }
 }
 
-@mixin invalidated-a-style{
-  a{
+@mixin invalidated-a-style {
+  a {
     color: inherit;
     text-decoration: none;
   }
 }
 
-@mixin white-text-box($expand:"false"){
+@mixin white-text-box($expand: "false") {
   background-color: white;
   border: none;
   border-radius: 4px;
   padding: 0.5rem;
-  @if $expand=="true"{
+  @if $expand== "true" {
     padding: 0.5rem 1rem;
   }
-  &:focus{
+  &:focus {
     outline: none;
   }
 }
 
-@mixin material-icon-button($size:"normal",$color:$text-gray,$border:"none"){
+@mixin material-icon-button(
+  $size: "normal",
+  $color: $text-gray,
+  $border: "none"
+) {
   width: 36px;
   height: 36px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border-radius: 100%;
-  &:hover,&:focus{
+  &:hover,
+  &:focus {
     cursor: pointer;
-    @if $color==#F07B7B{
-      background-color: rgba(240,123,123,0.2);
-    }
-    @else{
-      background-color: rgba(111,111,111,0.2);
+    @if $color==#F07B7B {
+      background-color: rgba(240, 123, 123, 0.2);
+    } @else {
+      background-color: rgba(111, 111, 111, 0.2);
     }
   }
-  .material-icons{
-    @if $size=="sm" {
+  .material-icons {
+    @if $size== "sm" {
       font-size: 8px;
-    }
-    @else if $size=="normal" {
+    } @else if $size== "normal" {
       font-size: 18px;
     }
-    @if $border=="solid"{
+    @if $border== "solid" {
       border: 2px solid;
       font-weight: bold;
     }
@@ -116,33 +114,34 @@
   }
 }
 
-
-@mixin home-event-list-element{
+@mixin home-event-list-element {
   display: flex;
   width: 100%;
   margin: 0 0 0.5rem 0;
-  @include white-text-box($expand:"true");
-  &--name{
+  @include white-text-box($expand: "true");
+  padding: 1rem;
+
+  &--name {
     width: 30%;
     @media screen and (min-width: $small+px) {
       width: 50%;
     }
   }
-  &--date{
+  &--date {
     margin: 0 0.5rem;
     @media screen and (min-width: $small+px) {
       margin: 0 2rem;
     }
   }
-  &--role{
+  &--role {
     flex: 1;
   }
-  &--status{
-    &--label{
+  &--status {
+    &--label {
       padding: 0px 6px !important;
       color: $danger;
       border-radius: 4px;
       border: 1px solid;
     }
-  }  
+  }
 }

--- a/app/front/pages/home.vue
+++ b/app/front/pages/home.vue
@@ -4,7 +4,7 @@
     <section class="home-top__new-event">
       <button class="home-top__new-event--button">
         <NuxtLink to="/room/create">
-          <span class="material-icons"> add </span>新しいイベントを追加
+          <span class="material-icons"> add </span>新しいイベントを作成
         </NuxtLink>
       </button>
     </section>

--- a/app/front/pages/home.vue
+++ b/app/front/pages/home.vue
@@ -85,7 +85,9 @@
             sushi-chat@example.com
           </div>
         </div>
-        <div class="home-top__account--logout-button">ログアウト</div>
+        <button class="home-top__account--logout-button" @click="logout()">
+          ログアウト
+        </button>
       </div>
     </section>
     <section class="home-top__other">
@@ -102,8 +104,19 @@ import { DeviceStore } from "~/store"
 export default Vue.extend({
   name: "Home",
   layout: "home",
+  middleware: "privateRoute",
   mounted(): void {
     DeviceStore.determineOs()
+  },
+  methods: {
+    async logout() {
+      try {
+        await this.$fire.auth.signOut()
+        this.$router.push("/login")
+      } catch {
+        alert("ログアウトに失敗しました")
+      }
+    },
   },
 })
 </script>

--- a/app/front/pages/login.vue
+++ b/app/front/pages/login.vue
@@ -15,9 +15,8 @@ export default Vue.extend({
       immediate: true,
       handler() {
         if (this.isLoggedIn) {
-          // ログイン済みの場合はプロフィールページへリダイレクトする
-          // TODO: 正しいリダイレクト先を設定
-          this.$router.push("/profile")
+          // NOTE: ログイン済みの場合はプロフィールページへリダイレクトする
+          this.$router.push("/home")
         }
       },
     },

--- a/app/front/pages/profile.vue
+++ b/app/front/pages/profile.vue
@@ -30,11 +30,7 @@ export default Vue.extend({
   methods: {
     async callSampleApi() {
       try {
-        const res = await this.$axios.$get("http://localhost:7000/auth-test", {
-          headers: {
-            Authorization: AuthStore.idToken,
-          },
-        })
+        const res = await this.$axios.$get("http://localhost:7000/auth-test")
         console.log(res)
       } catch (e) {
         console.log(e)

--- a/app/front/plugins/apiClient.ts
+++ b/app/front/plugins/apiClient.ts
@@ -3,6 +3,18 @@ import ApiClient from "~/apiClient"
 
 const repositoryPlugin: Plugin = (context, inject) => {
   const apiClient = new ApiClient(context.$axios)
+
+  // NOTE: idTokenの変更を監視して、変更があればAPIClientに反映する
+  context.store.watch(
+    (state) => state.auth._idToken,
+    (idToken: string | null) => {
+      apiClient.setToken(idToken)
+    },
+    {
+      immediate: true,
+    },
+  )
+
   inject("apiClient", apiClient)
 }
 

--- a/app/front/store/auth.ts
+++ b/app/front/store/auth.ts
@@ -36,7 +36,7 @@ export default class Auth extends VuexModule {
   }
 
   @Mutation
-  private setIdToken(idToken: string) {
+  private setIdToken(idToken: string | null) {
     this._idToken = idToken
   }
 
@@ -44,6 +44,7 @@ export default class Auth extends VuexModule {
   public async onIdTokenChangedAction(res: { authUser?: firebase.User }) {
     if (res.authUser == null) {
       this.setAuthUser(null)
+      this.setIdToken(null)
       return
     }
     const { uid, email, displayName, photoURL, emailVerified } = res.authUser


### PR DESCRIPTION
close #xxx

## やったこと
- authストア（firestoreの認証が同期されるVuex store）の変更に追従して、apiClientにtokenをセットするように変更
  - 既存実装より認証済みユーザーがAPIを叩いた場合は自動でAuthorizationヘッダにidTokenがセットされるはず
- ログイン後のリダイレクト先を/homeに変更
- /homeのログアウトを実装
- /homeにprivateRoutesのミドルウェア（未認証状態でアクセスするとログインページへリダイレクトされる）を適用
- /homeのデザインを微修正

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
