### PR TITLE
ルーム開始

### DIFF
--- a/app/front/components/AdminTool/AdminTool.vue
+++ b/app/front/components/AdminTool/AdminTool.vue
@@ -150,21 +150,8 @@ export default Vue.extend({
   methods: {
     // ルーム開始
     startRoom() {
-      console.log(this.roomId)
-      // TODO: ルームの状態をindex、またはvuexでもつ
-      this.$apiClient
-        .put(
-          {
-            pathname: "/room/:id/start",
-            params: { id: this.roomId },
-          },
-          {},
-        )
-        .then(() => {
-          this.isRoomStarted = true
-          socket.emit("ADMIN_START_ROOM", { roomId: this.roomId })
-        })
-        .catch(() => window.alert("ルームを開始できませんでした"))
+      this.$emit("start-room")
+      this.isRoomStarted = true
     },
     // ルーム終了
     finishRoom() {

--- a/app/front/components/AdminTool/AdminTool.vue
+++ b/app/front/components/AdminTool/AdminTool.vue
@@ -64,7 +64,7 @@
             >
               <span class="material-icons">restart_alt</span>
             </button>
-            <div v-if="!isRoomOngoing">
+            <div v-if="isRoomOngoing || isRoomFinished">
               <div class="topic-info">
                 334<span class="text-mini">users</span>
               </div>
@@ -115,17 +115,15 @@ export default Vue.extend({
       required: true,
     },
   },
-  data(): DataType {
-    return {
-      isRoomStartedInAdmin: this.isRoomStarted,
-    }
-  },
   computed: {
     isNotRoomStarted(): boolean {
       return this.roomState === "not-started"
     },
     isRoomOngoing(): boolean {
       return this.roomState === "ongoing"
+    },
+    isRoomFinished(): boolean {
+      return this.roomState === "finished"
     },
     topics(): Topic[] {
       return TopicStore.topics

--- a/app/front/components/AdminTool/AdminTool.vue
+++ b/app/front/components/AdminTool/AdminTool.vue
@@ -17,7 +17,7 @@
             </button>
           </div>
         </div>
-        <button v-if="!isRoomStarted" class="start-button" @click="startRoom">
+        <button v-if="isNotRoomStarted" class="start-button" @click="startRoom">
           <div class="material-icons-outlined">play_circle</div>
           <span>ルームを開始する</span>
         </button>
@@ -40,7 +40,7 @@
               >一時停止</span
             >
           </div>
-          <div v-if="isRoomStarted" class="buttons">
+          <div v-if="isRoomOngoing" class="buttons">
             <button
               v-if="topicStateItems[topic.id] != 'finished'"
               @click="clickPlayPauseButton(topic.id)"
@@ -64,7 +64,7 @@
             >
               <span class="material-icons">restart_alt</span>
             </button>
-            <div v-if="!isRoomStarted">
+            <div v-if="!isRoomOngoing">
               <div class="topic-info">
                 334<span class="text-mini">users</span>
               </div>
@@ -79,7 +79,7 @@
         </div>
       </div>
       <div class="drawer-menu__footer">
-        <button v-if="isRoomStarted" class="end-button" @click="finishRoom">
+        <button v-if="isRoomOngoing" class="end-button" @click="finishRoom">
           <span>ルームを終了する</span>
           <div class="material-icons-outlined danger">info</div>
         </button>
@@ -92,7 +92,6 @@
 import Vue from "vue"
 import ICONS from "@/utils/icons"
 import { Topic } from "@/models/contents"
-import socket from "~/utils/socketIO"
 import { UserItemStore, TopicStore, TopicStateItemStore } from "~/store"
 
 // Data型
@@ -111,8 +110,8 @@ export default Vue.extend({
       type: String,
       required: true,
     },
-    isRoomStarted: {
-      type: Boolean,
+    roomState: {
+      type: String,
       required: true,
     },
   },
@@ -122,6 +121,12 @@ export default Vue.extend({
     }
   },
   computed: {
+    isNotRoomStarted(): boolean {
+      return this.roomState === "not-started"
+    },
+    isRoomOngoing(): boolean {
+      return this.roomState === "ongoing"
+    },
     topics(): Topic[] {
       return TopicStore.topics
     },
@@ -155,14 +160,11 @@ export default Vue.extend({
     // ルーム開始
     startRoom() {
       this.$emit("start-room")
-      this.isRoomStartedInAdmin = true
     },
     // ルーム終了
     finishRoom() {
       if (confirm("本当にこのルームを終了しますか？この操作は取り消せません")) {
         this.$emit("finish-room")
-        // TODO: ルームの状態をindex、またはvuexでもつ
-        this.isRoomStartedInAdmin = false
       }
     },
     writeToClipboard(s: string) {

--- a/app/front/components/AdminTool/AdminTool.vue
+++ b/app/front/components/AdminTool/AdminTool.vue
@@ -97,7 +97,7 @@ import { UserItemStore, TopicStore, TopicStateItemStore } from "~/store"
 
 // Data型
 type DataType = {
-  isRoomStarted: boolean
+  isRoomStartedInAdmin: boolean
 }
 
 export default Vue.extend({
@@ -111,10 +111,14 @@ export default Vue.extend({
       type: String,
       required: true,
     },
+    isRoomStarted: {
+      type: Boolean,
+      required: true,
+    },
   },
   data(): DataType {
     return {
-      isRoomStarted: false,
+      isRoomStartedInAdmin: this.isRoomStarted,
     }
   },
   computed: {
@@ -151,14 +155,14 @@ export default Vue.extend({
     // ルーム開始
     startRoom() {
       this.$emit("start-room")
-      this.isRoomStarted = true
+      this.isRoomStartedInAdmin = true
     },
     // ルーム終了
     finishRoom() {
       if (confirm("本当にこのルームを終了しますか？この操作は取り消せません")) {
         this.$emit("finish-room")
         // TODO: ルームの状態をindex、またはvuexでもつ
-        this.isRoomStarted = false
+        this.isRoomStartedInAdmin = false
       }
     },
     writeToClipboard(s: string) {

--- a/app/front/components/AdminTool/AdminTool.vue
+++ b/app/front/components/AdminTool/AdminTool.vue
@@ -150,6 +150,7 @@ export default Vue.extend({
   methods: {
     // ルーム開始
     startRoom() {
+      console.log(this.roomId)
       // TODO: ルームの状態をindex、またはvuexでもつ
       this.$apiClient
         .put(
@@ -159,7 +160,10 @@ export default Vue.extend({
           },
           {},
         )
-        .then(() => (this.isRoomStarted = true))
+        .then(() => {
+          this.isRoomStarted = true
+          socket.emit("ADMIN_START_ROOM", { roomId: this.roomId })
+        })
         .catch(() => window.alert("ルームを開始できませんでした"))
     },
     // ルーム終了

--- a/app/front/components/AdminTool/AdminTool.vue
+++ b/app/front/components/AdminTool/AdminTool.vue
@@ -151,8 +151,16 @@ export default Vue.extend({
     // ルーム開始
     startRoom() {
       // TODO: ルームの状態をindex、またはvuexでもつ
-      socket.emit("ADMIN_START_ROOM", { roomId: this.roomId })
-      this.isRoomStarted = true
+      this.$apiClient
+        .put(
+          {
+            pathname: "/room/:id/start",
+            params: { id: this.roomId },
+          },
+          {},
+        )
+        .then(() => (this.isRoomStarted = true))
+        .catch(() => window.alert("ルームを開始できませんでした"))
     },
     // ルーム終了
     finishRoom() {

--- a/app/front/components/NotStarted.vue
+++ b/app/front/components/NotStarted.vue
@@ -2,9 +2,9 @@
   <div class="sushi-select not-started">
     <div class="not-started__title">suhi-chatへようこそ</div>
     <div class="not-started__textbox">
-      <div class="not-started__textbox--title">技育CAMPハッカソン vol.5</div>
+      <div class="not-started__textbox--title">{{ title }}</div>
       <div>
-        2日間(事前開発OK)で成果物を創ってエンジニアとしてレベルアップするオンラインハッカソン。テーマは「無駄開発」。
+        {{ description }}
       </div>
     </div>
     <div class="not-started__warning">
@@ -21,6 +21,16 @@ import Vue from "vue"
 
 export default Vue.extend({
   name: "NotStarted",
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    description: {
+      type: String,
+      required: true,
+    },
+  },
   methods: {
     onClickEnter() {
       this.$emit("check-status-and-action")

--- a/app/front/components/NotStarted.vue
+++ b/app/front/components/NotStarted.vue
@@ -11,7 +11,7 @@
       ルームはまだ開始されていないようです...<br />ルームが開始されましたら下記ボタンからご参加ください！
     </div>
     <div class="not-started__button">
-      <button>参加する！</button>
+      <button @click="onClickEnter()">参加する！</button>
     </div>
   </div>
 </template>
@@ -21,5 +21,10 @@ import Vue from "vue"
 
 export default Vue.extend({
   name: "NotStarted",
+  methods: {
+    onClickEnter() {
+      this.$emit("check-status-and-action")
+    },
+  },
 })
 </script>

--- a/app/front/components/SelectIconModal.vue
+++ b/app/front/components/SelectIconModal.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="sushi-select">
     <section class="sushi-select__header">
-      <h1 class="sushi-select__header--title">技育ハッカソンvol7</h1>
+      <h1 class="sushi-select__header--title">{{ title }}</h1>
       <p class="sushi-select__header--content">
-        2日間(事前開発OK)で成果物を創ってエンジニアとしてレベルアップするオンラインハッカソン。テーマは「無駄開発」。
+        {{ description }}
       </p>
     </section>
 
@@ -86,6 +86,16 @@ import { UserItemStore } from "~/store"
 
 export default Vue.extend({
   name: "SelectIconModal",
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    description: {
+      type: String,
+      required: true,
+    },
+  },
   computed: {
     myIconId() {
       return UserItemStore.userItems.myIconId

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -8,6 +8,8 @@
       />
       <NotStarted
         v-if="!isRoomStarted && !isAdmin"
+        :title="room.title"
+        :description="room.description"
         @check-status-and-action="checkStatusAndAction"
         @click-icon="clickIcon"
         @hide-modal="hide"

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -94,6 +94,7 @@ export default Vue.extend({
   mounted(): any {
     // roomId取得
     this.room.id = this.$route.query.roomId as string
+    console.log(this.room.id)
     if (this.room.id !== "") {
       // TODO: this.room.idが存在しない→404
     }

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -3,6 +3,8 @@
     <main>
       <SelectIconModal
         v-if="isRoomStarted && !isAdmin && !isRoomEnter"
+        :title="room.title"
+        :description="room.description"
         @click-icon="clickIcon"
         @hide-modal="hide"
       />

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -2,12 +2,12 @@
   <div class="container page">
     <main>
       <SelectIconModal
-        v-if="isRoomStart && !isAdmin && !isRoomEnter"
+        v-if="isRoomStarted && !isAdmin && !isRoomEnter"
         @click-icon="clickIcon"
         @hide-modal="hide"
       />
       <NotStarted
-        v-if="!isRoomStart && !isAdmin"
+        v-if="!isRoomStarted && !isAdmin"
         @check-status-and-action="checkStatusAndAction"
         @click-icon="clickIcon"
         @hide-modal="hide"
@@ -16,6 +16,7 @@
         v-if="isAdmin"
         :room-id="room.id"
         :title="room.title"
+        :is-started="isRoomStarted"
         @start-room="startRoom"
         @change-topic-state="changeTopicState"
         @finish-room="finishRoom"
@@ -75,7 +76,7 @@ export default Vue.extend({
     }
   },
   computed: {
-    isRoomStart(): boolean {
+    isRoomStarted(): boolean {
       return this.room.state === "ongoing"
     },
     isAdmin(): boolean {


### PR DESCRIPTION
close #xxx

## やったこと

ルームの画面に遷移したときに、状態によって画面を出し分ける(管理者、ルーム未開始の時のユーザー、ルーム開始済みの時のユーザー)
未開始モーダルと寿司選択モーダルにtitleとdescriotionを渡した

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

## 困っていること
<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
