### PR TITLE
スタンプが複数回呼ばれていたのを直した

### DIFF
--- a/app/front/components/FavoriteButton.vue
+++ b/app/front/components/FavoriteButton.vue
@@ -80,11 +80,7 @@ export default Vue.extend({
   },
   computed: {
     stamps(): StampModel[] {
-      return StampStore.stamps.filter(
-        // 自分が押したものも通知されるため省く処理
-        (stamp) =>
-          stamp.topicId === this.topicId && stamp.id !== this.$socket().id,
-      )
+      return StampStore.stamps.filter((stamp) => stamp.topicId === this.topicId)
     },
   },
   watch: {

--- a/app/front/store/stamps.ts
+++ b/app/front/store/stamps.ts
@@ -24,12 +24,13 @@ export default class Stamps extends VuexModule {
   @Action({ rawError: true })
   public sendFavorite(topicId: number) {
     const socket = buildSocket(AuthStore.idToken)
-    this.add({
-      id: getUUID(),
-      topicId,
-      timestamp: 1000, // TODO: 正しいタイムスタンプを設定する
-      createdAt: new Date().toISOString(),
-    })
+    // StampStoreは配信で追加する
+    // this.add({
+    //   id: getUUID(),
+    //   topicId,
+    //   timestamp: 1000, // TODO: 正しいタイムスタンプを設定する
+    //   createdAt: new Date().toISOString(),
+    // })
     socket.emit("POST_STAMP", { topicId }, (res: any) => {
       console.log(res)
     })


### PR DESCRIPTION
## やったこと
スタンプのStoreへの追加は配信によって行うこととした(1クリックでスタンプアニメーションを呼ばれる回数が1回減る)

## やっていないこと
スタンプの重複判定

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
