### PR TITLE
[fix]ヘッダーとテキストエリアでindex違う

### DIFF
--- a/app/front/components/ChatRoom.vue
+++ b/app/front/components/ChatRoom.vue
@@ -2,7 +2,7 @@
   <article v-if="topic" class="topic-block">
     <TopicHeader
       :title="topic.title"
-      :topic-index="topicIndex"
+      :topic-index="topicId"
       :bookmark-item="pinnedChatItem"
       @download="clickDownload"
       @click-show-all="clickShowAll"


### PR DESCRIPTION
close #497 

## やったこと
ヘッダーにはtopicIndexが渡され、テキストエリアにはtopicIdが渡されてたせいでズレが発生していたのでtopicIdに統一

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
