### PR TITLE
senderTypeの出しわけ

### DIFF
--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -371,7 +371,7 @@
     display: flex;
     padding: 0.5em 1em;
   }
-  .presenter {
+  .speaker {
     background-color: $primary;
   }
   .admin {

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -552,6 +552,11 @@
     border-bottom-right-radius: 5px;
     min-width: 7rem;
   }
+  .sender-non-badge {
+    display: inline-block;
+    background-color: white;
+    color: white;
+  }
 
   .admin {
     & > .sender-badge {

--- a/app/front/components/ChatRoom.vue
+++ b/app/front/components/ChatRoom.vue
@@ -27,7 +27,6 @@
                 message.type == 'question' ||
                 message.type == 'answer'
               "
-              :message-id="message.id"
               :topic-id="topicId"
               :message="message"
               @click-thumb-up="clickReaction"

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -2,8 +2,8 @@
   <div class="chatitem-wrapper">
     <!-- Message -->
     <article
-      v-if="message.type != 'reaction'"
-      :id="messageId"
+      v-if="message.type != 'reaction' && message.senderType !== 'system'"
+      :id="message.id"
       class="comment"
       :class="{
         admin: message.iconId == 0,
@@ -11,7 +11,14 @@
         answer: message.type == 'answer',
       }"
     >
-      <div class="sender-badge">from おすしアカデミー</div>
+      <!-- バッジ -->
+      <div v-if="message.senderType === 'admin'" class="sender-badge">
+        from 運営
+      </div>
+      <div v-else-if="message.senderType === 'speaker'" class="sender-badge">
+        from スピーカー
+      </div>
+      <div v-else class="sender-non-badge"></div>
       <div class="main-contents">
         <div class="icon-wrapper">
           <picture>
@@ -78,7 +85,7 @@
     <!--Reaction Message-->
     <article
       v-else-if="message.type == 'reaction'"
-      :id="messageId"
+      :id="message.id"
       class="reaction"
     >
       <div class="icon-wrapper">
@@ -104,18 +111,13 @@
       </span>
     </article>
     <!--System Message-->
-    <!--article class="system_message" :id="messageId">
-      <UrlToLink :text="message.content" />
-    </article-->
-    <!-- <button
-      v-if="message.type != 'reaction'"
-      class="chatitem__bookmark"
-      @click="bookmark()"
+    <article
+      v-if="message.senderType === 'system'"
+      :id="message.id"
+      class="system_message"
     >
-      <span class="material-icons" :class="{ selected: isBookMarked }"
-        >push_pin</span
-      >
-    </button> -->
+      <UrlToLink :text="message.content" />
+    </article>
   </div>
 </template>
 <script lang="ts">
@@ -141,10 +143,6 @@ export default Vue.extend({
       type: Object,
       required: true,
     } as PropOptions<ChatItemModel>,
-    messageId: {
-      type: String,
-      required: true,
-    },
     topicId: {
       type: Number,
       required: true,

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -168,7 +168,10 @@ export default Vue.extend({
       return this.pinnedChatItems.includes(this.message.id)
     },
     isAdminorSpeaker(): boolean {
-      return UserItemStore.userItems.isAdmin
+      return (
+        UserItemStore.userItems.isAdmin ||
+        UserItemStore.userItems.speakerId === this.topicId
+      )
     },
   },
   methods: {

--- a/app/front/components/SelectIconModal.vue
+++ b/app/front/components/SelectIconModal.vue
@@ -49,9 +49,15 @@
             </div>
           </span>
         </div>
-        <select name="speaker" class="sushi-select__section--speaker">
-          <option>未選択</option>
-          <option>おすしアカデミー</option>
+        <select
+          v-model="speakerId"
+          name="speaker"
+          class="sushi-select__section--speaker"
+        >
+          <option :value="0">未選択</option>
+          <option v-for="topic in topics" :key="topic.id" :value="topic.id">
+            {{ topic.title }}
+          </option>
         </select>
       </article>
     </section>
@@ -82,7 +88,7 @@
 <script lang="ts">
 import Vue from "vue"
 import ICONS from "@/utils/icons"
-import { UserItemStore } from "~/store"
+import { TopicStore, UserItemStore } from "~/store"
 
 export default Vue.extend({
   name: "SelectIconModal",
@@ -96,6 +102,11 @@ export default Vue.extend({
       default: "",
     },
   },
+  data() {
+    return {
+      speakerId: 0,
+    }
+  },
   computed: {
     myIconId() {
       return UserItemStore.userItems.myIconId
@@ -103,12 +114,16 @@ export default Vue.extend({
     userIcons() {
       return ICONS.slice(1)
     },
+    topics() {
+      return TopicStore.topics
+    },
   },
   methods: {
     selectIcon(index: number) {
       this.$emit("click-icon", index + 1)
     },
     hideModal() {
+      UserItemStore.setSpeakerId(this.speakerId)
       this.$emit("hide-modal")
     },
   },

--- a/app/front/components/TextArea.vue
+++ b/app/front/components/TextArea.vue
@@ -13,16 +13,10 @@
       </div>
       <div class="material-icons" @click="deselectChatItem">close</div>
     </div>
-    <div class="sender-badge-wrapper">
-      <span
-        v-if="selectedChatItem === null"
-        class="sender-badge"
-        :class="{
-          admin: isAdmin === true,
-          presenter: isAdmin === false,
-        }"
-      >
-        from おすしアカデミー
+    <div v-if="selectedChatItem === null" class="sender-badge-wrapper">
+      <span v-if="isAdmin" class="sender-badge admin"> from 運営 </span>
+      <span v-if="isSpeaker" class="sender-badge speaker">
+        from スピーカー
       </span>
     </div>
     <!--div class="input-area__fixed-phrases">
@@ -123,6 +117,9 @@ export default Vue.extend({
     },
     isAdmin() {
       return UserItemStore.userItems.isAdmin
+    },
+    isSpeaker(): boolean {
+      return UserItemStore.userItems.speakerId === this.topicId
     },
   },
   methods: {

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -252,7 +252,7 @@ export default Vue.extend({
         {
           iconId,
           roomId: this.room.id,
-          speakerTopicId: 0, // TODO: speakerTopicIdを渡す
+          speakerTopicId: UserItemStore.userItems.speakerId,
         },
         (res) => {
           if (res.result === "error") {

--- a/app/front/store/userItems.ts
+++ b/app/front/store/userItems.ts
@@ -3,6 +3,7 @@ import { Module, VuexModule, Mutation } from "vuex-module-decorators"
 type UserItem = {
   myIconId: number
   isAdmin: boolean
+  speakerId: number
 }
 
 @Module({
@@ -11,7 +12,7 @@ type UserItem = {
   namespaced: true,
 })
 export default class UserItems extends VuexModule {
-  private _userItems: UserItem = { myIconId: 1, isAdmin: false }
+  private _userItems: UserItem = { myIconId: 1, isAdmin: false, speakerId: 0 }
 
   public get userItems(): UserItem {
     return this._userItems
@@ -25,5 +26,10 @@ export default class UserItems extends VuexModule {
   @Mutation
   public changeIsAdmin(state: boolean) {
     this._userItems.isAdmin = state
+  }
+
+  @Mutation
+  public setSpeakerId(id: number) {
+    this._userItems.speakerId = id
   }
 }


### PR DESCRIPTION
close #459 

## やったこと
senderTypeに応じてmessageの出しわけ(socketにspeakerIdわたした)
TextAreaに表示した

## やっていないこと
通常ユーザーの場合messageの上の白が気になるかも
senderType=system

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
